### PR TITLE
clone时修改项目名，也能正确找到项目根目录

### DIFF
--- a/core/utils/util.py
+++ b/core/utils/util.py
@@ -5,9 +5,8 @@ import socket
 
 
 def get_project_dir():
-    projectName = 'xiaozhi-esp32-server'
-    filePath = os.path.abspath(__file__)
-    return filePath[:filePath.rfind('/' + projectName + '/') + len(projectName) + 2]
+    """获取项目根目录"""
+    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))+'/'
 
 
 def get_local_ip():


### PR DESCRIPTION
clone时本地保存的项目名字变了，无法找到正确的根目录，采用向上跳三层目录的方式寻找，而不是根据特定字符串匹配识别，通用性更好