### PR TITLE
为服务端添加阿里系列的视觉识别模型能力

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -104,10 +104,9 @@ LLM:
     # 定义LLM API类型
     type: openai
     # 可在这里找到你的 api_key https://bailian.console.aliyun.com/?apiKey=1#/api-key
-    #qwen-omni-turbo
-    #qwen-omni-turbo 这个模型支持视觉识别
+    #qwen-omni-turbo 可使用一系列阿里的视觉识别模型
     base_url: https://dashscope.aliyuncs.com/compatible-mode/v1
-    model_name: qwen-omni-turbo #qwen-omni-turbo
+    model_name: qwen-turbo
     api_key: 你的deepseek api key
   DeepSeekLLM:
     # 定义LLM API类型

--- a/config.yaml
+++ b/config.yaml
@@ -77,7 +77,7 @@ selected_module:
   ASR: FunASR
   VAD: SileroVAD
   # 将根据配置名称对应的type调用实际的LLM适配器
-  LLM: ChatGLMLLM
+  LLM: AliLLM
   # TTS将根据配置名称对应的type调用实际的TTS适配器
   TTS: EdgeTTS
 
@@ -104,8 +104,10 @@ LLM:
     # 定义LLM API类型
     type: openai
     # 可在这里找到你的 api_key https://bailian.console.aliyun.com/?apiKey=1#/api-key
+    #qwen-omni-turbo
+    #qwen-omni-turbo 这个模型支持视觉识别
     base_url: https://dashscope.aliyuncs.com/compatible-mode/v1
-    model_name: qwen-turbo
+    model_name: qwen-omni-turbo #qwen-omni-turbo
     api_key: 你的deepseek api key
   DeepSeekLLM:
     # 定义LLM API类型

--- a/core/connection.py
+++ b/core/connection.py
@@ -167,6 +167,8 @@ class ConnectionHandler:
     async def _route_message(self, message):
         """消息路由"""
         if isinstance(message, str):
+            print('str')
+            print(message)
             await handleTextMessage(self, message)
         elif isinstance(message, bytes):
             await handleAudioMessage(self, message)

--- a/core/connection.py
+++ b/core/connection.py
@@ -167,8 +167,6 @@ class ConnectionHandler:
     async def _route_message(self, message):
         """消息路由"""
         if isinstance(message, str):
-            print('str')
-            print(message)
             await handleTextMessage(self, message)
         elif isinstance(message, bytes):
             await handleAudioMessage(self, message)

--- a/core/handle/VLHandle.py
+++ b/core/handle/VLHandle.py
@@ -1,0 +1,12 @@
+import json
+from config.logger import setup_logging
+
+logger = setup_logging()
+
+async def handleVLMessage(conn, text):
+    messages =  [
+        {"type": "image_url","image_url": {"url": f"data:image/png;base64,{text}"},},
+        {"type": "text", "text": "图中描绘的是什么景象,请细致查看并描述"},
+    ]
+    conn.executor.submit(conn.chat, messages)
+    await conn.websocket.send(json.dumps(conn.welcome_msg))

--- a/core/handle/VLHandle.py
+++ b/core/handle/VLHandle.py
@@ -9,4 +9,3 @@ async def handleVLMessage(conn, text):
         {"type": "text", "text": "图中描绘的是什么景象,请细致查看并描述"},
     ]
     conn.executor.submit(conn.chat, messages)
-    await conn.websocket.send(json.dumps(conn.welcome_msg))

--- a/core/handle/textHandle.py
+++ b/core/handle/textHandle.py
@@ -2,6 +2,7 @@ from config.logger import setup_logging
 import json
 from core.handle.abortHandle import handleAbortMessage
 from core.handle.helloHandle import handleHelloMessage
+from core.handle.VLHandle import handleVLMessage
 from core.handle.receiveAudioHandle import startToChat
 from core.handle.iotHandle import handleIotDescriptors
 
@@ -40,5 +41,9 @@ async def handleTextMessage(conn, message):
         elif msg_json["type"] == "iot":
             if "descriptors" in msg_json:
                 await handleIotDescriptors(conn, msg_json["descriptors"])
+         ####视觉识别添加能力 msg中应该包含图片数据
+        elif msg_json["type"] == "VL":
+            await handleVLMessage(conn, msg_json['msg'])
+
     except json.JSONDecodeError:
         await conn.websocket.send(message)

--- a/core/providers/llm/openai/openai.py
+++ b/core/providers/llm/openai/openai.py
@@ -23,7 +23,10 @@ class LLMProvider(LLMProviderBase):
             responses = self.client.chat.completions.create(
                 model=self.model_name,
                 messages=dialogue,
-                stream=True
+                # 设置输出数据的模态，当前支持["text"]
+                modalities=["text"],
+                stream=True,
+                stream_options={"include_usage": True}
             )
             
             is_active = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+#pip install -r requirements.txt -i https://mirrors.aliyun.com/pypi/simple
 pyyml==0.0.2
 torch==2.2.2
 silero_vad==5.1.2


### PR DESCRIPTION
为服务端添加视觉识别的能力

客户端只需要发送的消息类型：
            vl_message = {
                "type": "VL",
                "msg": base64(你的图片)
                "version": 1,
                "transport": "websocket",
                "audio_params": {
                    "format": "opus",
                    "sample_rate": 16000,
                    "channels": 1,
                    "frame_duration": 60
                }