### PR TITLE
fix(tts.base): 修复 AudioSegment.from_file 读取音频时阻塞的问题

### DIFF
--- a/main/xiaozhi-server/core/providers/tts/base.py
+++ b/main/xiaozhi-server/core/providers/tts/base.py
@@ -47,7 +47,8 @@ class TTSProviderBase(ABC):
         file_type = os.path.splitext(audio_file_path)[1]
         if file_type:
             file_type = file_type.lstrip('.')
-        audio = AudioSegment.from_file(audio_file_path, format=file_type)
+        # 读取音频文件，-nostdin 参数：不要从标准输入读取数据，否则FFmpeg会阻塞
+        audio = AudioSegment.from_file(audio_file_path, format=file_type, parameters=["-nostdin"])
 
         # 转换为单声道/16kHz采样率/16位小端编码（确保与编码器匹配）
         audio = audio.set_channels(1).set_frame_rate(16000).set_sample_width(2)


### PR DESCRIPTION
在tts.base的`AudioSegment.from_file`处额外传递 `-nostdin` 参数，防止 FFmpeg 在`Windows `环境下等待标准输入，导致阻塞执行。