### PR TITLE
Update vue.config.js

### DIFF
--- a/main/manager-web/vue.config.js
+++ b/main/manager-web/vue.config.js
@@ -7,6 +7,7 @@ dotenv.config();
 module.exports = defineConfig({
     devServer: {
       // Bug 修复：将代理配置为环境变量中定义的 API 基础 URL
+      port: 8001, // 指定端口为 8001
       proxy: {
         '/xiaozhi-esp32-api': {
           target: process.env.VUE_APP_API_BASE_URL || 'http://localhost:8002', // 后端 API 的基础 URL


### PR DESCRIPTION
Bug 修复：在启动manger-web连接服务端时，默认为8080端口。此处应按main/README.md文档说明，指定端口为 8001。