### PR TITLE
修复无法切分英文导致 TTS 超时错误

### DIFF
--- a/main/xiaozhi-server/core/connection.py
+++ b/main/xiaozhi-server/core/connection.py
@@ -382,7 +382,7 @@ class ConnectionHandler:
                     current_text = full_text[processed_chars:]  # 从未处理的位置开始
 
                     # 查找最后一个有效标点
-                    punctuations = ("。", "？", "！", "；", "：")
+                    punctuations = ("。", "？", "！", "；", "：", ".", "?", "!", ";", ":")
                     last_punct_pos = -1
                     for punct in punctuations:
                         pos = current_text.rfind(punct)


### PR DESCRIPTION
<img width="1516" alt="截屏2025-03-23 上午9 16 27" src="https://github.com/user-attachments/assets/58960c93-7045-4428-8618-5b6496a5d1c4" />
