### PR TITLE
意图识别intent_llm单独配置独立的LLM，意图识别intent_llm增加天气和新闻查询function

### DIFF
--- a/main/xiaozhi-server/config.yaml
+++ b/main/xiaozhi-server/config.yaml
@@ -86,7 +86,7 @@ selected_module:
   # 意图识别使用intent_llm，优点：通用性强，缺点：增加串行前置意图识别模块，会增加处理时间
   # 意图识别使用function_call，缺点：需要所选择的LLM支持function_call，优点：按需调用工具、速度快
   # 默认免费的ChatGLMLLM就已经支持function_call，但是如果像追求稳定建议把LLM设置成：DoubaoLLM，使用的具体model_name是：doubao-pro-32k-functioncall-241028
-  Intent: function_call
+  Intent: intent_llm
 
 # 意图识别，是用于理解用户意图的模块，例如：播放音乐
 Intent:

--- a/main/xiaozhi-server/config.yaml
+++ b/main/xiaozhi-server/config.yaml
@@ -88,6 +88,9 @@ selected_module:
   # 默认免费的ChatGLMLLM就已经支持function_call，但是如果像追求稳定建议把LLM设置成：DoubaoLLM，使用的具体model_name是：doubao-pro-32k-functioncall-241028
   Intent: intent_llm
 
+# 意图识别专用LLM配置，如果设置，则意图识别会使用这个模型而不是主LLM
+IntentLLM: XinferenceSmallLLM #ChatGLMLLM #XinferenceSmallLLM # 设置为空字符串""或不设置则使用主LLM
+
 # 意图识别，是用于理解用户意图的模块，例如：播放音乐
 Intent:
   # 不使用意图识别
@@ -181,6 +184,18 @@ VAD:
 LLM:
   # 所有openai类型均可以修改超参，以AliLLM为例
   # 当前支持的type为openai、dify、ollama，可自行适配
+  XinferenceLLM:
+    # 定义LLM API类型
+    type: xinference
+    # Xinference服务地址和模型名称
+    model_name: qwen2.5:72b-AWQ  # 使用的模型名称，需要预先在Xinference启动对应模型
+    base_url: http://localhost:9997  # Xinference服务地址
+  XinferenceSmallLLM:
+    # 定义轻量级LLM API类型，用于意图识别
+    type: xinference
+    # Xinference服务地址和模型名称
+    model_name: qwen2.5:3b-AWQ  # 使用的小模型名称，用于意图识别
+    base_url: http://localhost:9997  # Xinference服务地址
   AliLLM:
     # 定义LLM API类型
     type: openai

--- a/main/xiaozhi-server/core/handle/intentHandler.py
+++ b/main/xiaozhi-server/core/handle/intentHandler.py
@@ -4,6 +4,9 @@ import uuid
 from core.handle.sendAudioHandle import send_stt_message
 from core.handle.helloHandle import checkWakeupWords
 from core.utils.util import remove_punctuation_and_length
+import re
+import asyncio
+from loguru import logger
 
 TAG = __name__
 logger = setup_logging()
@@ -21,11 +24,11 @@ async def handle_user_intent(conn, text):
         # 使用支持function calling的聊天方法,不再进行意图分析
         return False
     # 使用LLM进行意图分析
-    intent = await analyze_intent_with_llm(conn, text)
-    if not intent:
+    intent_result = await analyze_intent_with_llm(conn, text)
+    if not intent_result:
         return False
     # 处理各种意图
-    return await process_intent_result(conn, intent, text)
+    return await process_intent_result(conn, intent_result, text)
 
 
 async def check_direct_exit(conn, text):
@@ -40,7 +43,6 @@ async def check_direct_exit(conn, text):
     return False
 
 
-
 async def analyze_intent_with_llm(conn, text):
     """使用LLM分析用户意图"""
     if not hasattr(conn, 'intent') or not conn.intent:
@@ -51,49 +53,251 @@ async def analyze_intent_with_llm(conn, text):
     dialogue = conn.dialogue
     try:
         intent_result = await conn.intent.detect_intent(conn, dialogue.dialogue, text)
-        # 尝试解析JSON结果
-        try:
-            intent_data = json.loads(intent_result)
-            if "intent" in intent_data:
-                return intent_data["intent"]
-        except json.JSONDecodeError:
-            # 如果不是JSON格式，尝试直接获取意图文本
-            return intent_result.strip()
-
+        return intent_result
     except Exception as e:
         logger.bind(tag=TAG).error(f"意图识别失败: {str(e)}")
 
     return None
 
 
-async def process_intent_result(conn, intent, original_text):
+async def process_intent_result(conn, intent_result, original_text):
     """处理意图识别结果"""
-    # 处理退出意图
-    if "结束聊天" in intent:
-        logger.bind(tag=TAG).info(f"识别到退出意图: {intent}")
-        # 如果是明确的离别意图，发送告别语并关闭连接
-        await send_stt_message(conn, original_text)
-        conn.executor.submit(conn.chat_and_close, original_text)
-        return True
+    try:
+        # 尝试将结果解析为JSON
+        intent_data = json.loads(intent_result)
+        
+        # 检查是否有function_call
+        if "function_call" in intent_data:
+            # 直接从意图识别获取了function_call
+            logger.bind(tag=TAG).info(f"检测到function_call格式的意图结果: {intent_data['function_call']['name']}")
+            
+            function_name = intent_data["function_call"]["name"]
+            function_args = intent_data["function_call"]["arguments"]
+            
+            # 确保参数是字符串格式的JSON
+            if isinstance(function_args, dict):
+                function_args = json.dumps(function_args)
+            
+            function_call_data = {
+                "name": function_name,
+                "id": str(uuid.uuid4().hex),
+                "arguments": function_args
+            }
+            
+            # 处理特定类型的函数调用
+            if function_name == "get_weather":
+                logger.bind(tag=TAG).info(f"识别到天气查询意图")
+                # 先发送消息确认
+                await send_stt_message(conn, original_text)
+                
+                # 使用executor执行函数调用和结果处理
+                def process_weather_query():
+                    # 直接调用函数
+                    result = conn.func_handler.handle_llm_function_call(conn, function_call_data)
+                    if result:
+                        # 获取当前最新的文本索引
+                        text_index = conn.tts_last_text_index + 1 if hasattr(conn, 'tts_last_text_index') else 0
+                        # 处理函数调用结果
+                        conn._handle_function_result(result, function_call_data, text_index)
+                
+                # 将函数执行放在线程池中
+                conn.executor.submit(process_weather_query)
+                return True
+                
+            elif function_name == "play_music":
+                logger.bind(tag=TAG).info(f"识别到音乐播放意图")
+                # 先发送消息确认
+                await send_stt_message(conn, original_text)
+                
+                # 使用executor执行函数调用和结果处理
+                def process_music_query():
+                    # 直接调用函数
+                    result = conn.func_handler.handle_llm_function_call(conn, function_call_data)
+                    if result:
+                        # 获取当前最新的文本索引
+                        text_index = conn.tts_last_text_index + 1 if hasattr(conn, 'tts_last_text_index') else 0
+                        # 处理函数调用结果
+                        conn._handle_function_result(result, function_call_data, text_index)
+                
+                # 将函数执行放在线程池中
+                conn.executor.submit(process_music_query)
+                return True
+                
+            elif function_name == "get_news":
+                logger.bind(tag=TAG).info(f"识别到新闻查询意图")
+                # 先发送消息确认
+                await send_stt_message(conn, original_text)
+                
+                # 使用executor执行函数调用和结果处理
+                def process_news_query():
+                    # 直接调用函数
+                    result = conn.func_handler.handle_llm_function_call(conn, function_call_data)
+                    if result:
+                        # 获取当前最新的文本索引
+                        text_index = conn.tts_last_text_index + 1 if hasattr(conn, 'tts_last_text_index') else 0
+                        # 处理函数调用结果
+                        conn._handle_function_result(result, function_call_data, text_index)
+                
+                # 将函数执行放在线程池中
+                conn.executor.submit(process_news_query)
+                return True
+                
+            else:
+                # 其他类型的函数调用，尝试直接执行
+                # 先发送消息确认
+                await send_stt_message(conn, original_text)
+                
+                # 使用executor执行函数调用和结果处理
+                def process_function_call():
+                    result = conn.func_handler.handle_llm_function_call(conn, function_call_data)
+                    if result:
+                        # 获取当前最新的文本索引
+                        text_index = conn.tts_last_text_index + 1 if hasattr(conn, 'tts_last_text_index') else 0
+                        # 处理函数调用结果
+                        conn._handle_function_result(result, function_call_data, text_index)
+                
+                # 将函数执行放在线程池中
+                conn.executor.submit(process_function_call)
+                return True
+            
+        # 处理传统意图格式
+        elif "intent" in intent_data:
+            intent = intent_data["intent"]
+            
+            # 处理退出意图
+            if "结束聊天" in intent:
+                logger.bind(tag=TAG).info(f"识别到退出意图: {intent}")
+                # 如果是明确的离别意图，发送告别语并关闭连接
+                await send_stt_message(conn, original_text)
+                conn.executor.submit(conn.chat_and_close, original_text)
+                return True
+                
+            # 其他不需要特殊处理的意图，让常规聊天流程处理
+            return False
+            
+    except json.JSONDecodeError:
+        # 如果不是有效的JSON，尝试兼容旧格式
+        intent = intent_result
+        
+        # 处理退出意图
+        if "结束聊天" in intent:
+            logger.bind(tag=TAG).info(f"识别到退出意图: {intent}")
+            # 如果是明确的离别意图，发送告别语并关闭连接
+            await send_stt_message(conn, original_text)
+            conn.executor.submit(conn.chat_and_close, original_text)
+            return True
 
-    # 处理播放音乐意图
-    if "播放音乐" in intent:
-        logger.bind(tag=TAG).info(f"识别到音乐播放意图: {intent}")
-        # 调用play_music函数来播放音乐
-        song_name = extract_text_in_brackets(intent)
-        function_id = str(uuid.uuid4().hex)
-        function_name = "play_music"
-        function_arguments = '{ "song_name": "' + song_name + '" }'
-
-        function_call_data = {
-            "name": function_name,
-            "id": function_id,
-            "arguments": function_arguments
-        }
-        conn.func_handler.handle_llm_function_call(conn, function_call_data)
-        return True
-
-    # 其他意图处理可以在这里扩展
+        # 处理播放音乐意图
+        if "播放音乐" in intent:
+            logger.bind(tag=TAG).info(f"识别到音乐播放意图: {intent}")
+            # 获取歌曲名称
+            song_name = extract_text_in_brackets(intent)
+            
+            # 先发送消息确认
+            await send_stt_message(conn, original_text)
+            
+            # 构造合适的音乐播放函数调用
+            function_id = str(uuid.uuid4().hex)
+            function_name = "play_music"
+            function_arguments = '{ "song_name": ' + (f'"{song_name}"' if song_name else '"random"') + ' }'
+            
+            function_call_data = {
+                "name": function_name,
+                "id": function_id,
+                "arguments": function_arguments
+            }
+            
+            # 使用executor执行函数调用和结果处理
+            def process_music_query():
+                # 直接调用函数
+                result = conn.func_handler.handle_llm_function_call(conn, function_call_data)
+                if result:
+                    # 获取当前最新的文本索引
+                    text_index = conn.tts_last_text_index + 1 if hasattr(conn, 'tts_last_text_index') else 0
+                    # 处理函数调用结果
+                    conn._handle_function_result(result, function_call_data, text_index)
+            
+            # 将函数执行放在线程池中
+            conn.executor.submit(process_music_query)
+            return True
+            
+        # 处理查询天气意图
+        if "查询天气" in intent:
+            logger.bind(tag=TAG).info(f"识别到天气查询意图: {intent}")
+            # 获取地点
+            location = extract_text_in_brackets(intent)
+            
+            # 先发送消息确认
+            await send_stt_message(conn, original_text)
+            
+            # 构造合适的天气查询函数调用
+            function_id = str(uuid.uuid4().hex)
+            function_name = "get_weather"
+            function_arguments = '{ "location": ' + (f'"{location}"' if location and location != "当前位置" else 'null') + ', "lang": "zh_CN" }'
+            
+            function_call_data = {
+                "name": function_name,
+                "id": function_id,
+                "arguments": function_arguments
+            }
+            
+            # 使用executor执行函数调用和结果处理
+            def process_weather_query():
+                # 直接调用函数
+                result = conn.func_handler.handle_llm_function_call(conn, function_call_data)
+                if result:
+                    # 获取当前最新的文本索引
+                    text_index = conn.tts_last_text_index + 1 if hasattr(conn, 'tts_last_text_index') else 0
+                    # 处理函数调用结果
+                    conn._handle_function_result(result, function_call_data, text_index)
+            
+            # 将函数执行放在线程池中
+            conn.executor.submit(process_weather_query)
+            return True
+            
+        # 处理查询新闻意图
+        if "查询新闻" in intent or "播报新闻" in intent or "看新闻" in intent:
+            logger.bind(tag=TAG).info(f"识别到新闻查询意图: {intent}")
+            # 获取新闻类别
+            category = extract_text_in_brackets(intent)
+            
+            # 先发送消息确认
+            await send_stt_message(conn, original_text)
+            
+            # 构造合适的新闻查询函数调用
+            function_id = str(uuid.uuid4().hex)
+            function_name = "get_news"
+            
+            # 判断是否是查询详情
+            detail = "详情" in intent or "详细" in intent
+            
+            # 构造参数JSON字符串
+            if detail:
+                function_arguments = '{ "detail": true, "lang": "zh_CN" }'
+            else:
+                function_arguments = '{ "category": ' + (f'"{category}"' if category else 'null') + ', "detail": false, "lang": "zh_CN" }'
+            
+            function_call_data = {
+                "name": function_name,
+                "id": function_id,
+                "arguments": function_arguments
+            }
+            
+            # 使用executor执行函数调用和结果处理
+            def process_news_query():
+                # 直接调用函数
+                result = conn.func_handler.handle_llm_function_call(conn, function_call_data)
+                if result:
+                    # 获取当前最新的文本索引
+                    text_index = conn.tts_last_text_index + 1 if hasattr(conn, 'tts_last_text_index') else 0
+                    # 处理函数调用结果
+                    conn._handle_function_result(result, function_call_data, text_index)
+            
+            # 将函数执行放在线程池中
+            conn.executor.submit(process_news_query)
+            return True
+    except Exception as e:
+        logger.bind(tag=TAG).error(f"处理意图结果时出错: {e}")
 
     # 默认返回False，表示继续常规聊天流程
     return False

--- a/main/xiaozhi-server/core/providers/intent/base.py
+++ b/main/xiaozhi-server/core/providers/intent/base.py
@@ -12,12 +12,22 @@ class IntentProviderBase(ABC):
         self.intent_options = config.get("intent_options", {
             "continue_chat": "继续聊天",
             "end_chat": "结束聊天",
-            "play_music": "播放音乐"
+            "play_music": "播放音乐",
+            "get_weather": "查询天气",
+            "get_news": "查询新闻"
         })
 
     def set_llm(self, llm):
         self.llm = llm
-        logger.bind(tag=TAG).debug("Set LLM for intent provider")
+        # 获取模型名称和类型信息
+        model_name = getattr(llm, 'model_name', str(llm.__class__.__name__))
+        model_type = getattr(llm, 'type', 'unknown')
+        # 记录更详细的日志
+        logger.bind(tag=TAG).info(f"意图识别设置LLM: {model_name}, 类型: {model_type}")
+        # 尝试获取模型基础URL
+        base_url = getattr(llm, 'base_url', 'N/A')
+        if base_url != 'N/A':
+            logger.bind(tag=TAG).debug(f"意图识别LLM基础URL: {base_url}")
 
     @abstractmethod
     async def detect_intent(self, conn, dialogue_history: List[Dict], text: str) -> str:
@@ -30,5 +40,6 @@ class IntentProviderBase(ABC):
             - "继续聊天"
             - "结束聊天" 
             - "播放音乐 歌名" 或 "随机播放音乐"
+            - "查询天气 地点名" 或 "查询天气 [当前位置]"
         """
         pass

--- a/main/xiaozhi-server/core/providers/intent/intent_llm/intent_llm.py
+++ b/main/xiaozhi-server/core/providers/intent/intent_llm/intent_llm.py
@@ -3,6 +3,9 @@ from ..base import IntentProviderBase
 from plugins_func.functions.play_music import initialize_music_handler
 from config.logger import setup_logging
 import re
+import json
+import hashlib
+import time
 
 TAG = __name__
 logger = setup_logging()
@@ -13,6 +16,23 @@ class IntentProvider(IntentProviderBase):
         super().__init__(config)
         self.llm = None
         self.promot = self.get_intent_system_prompt()
+        # 添加缓存管理
+        self.intent_cache = {}  # 缓存意图识别结果
+        self.cache_expiry = 600  # 缓存有效期10分钟
+        self.cache_max_size = 100  # 最多缓存100个意图
+        self.common_patterns = {
+            "天气": '{\"function_call\": {\"name\": \"get_weather\", \"arguments\": {\"location\": null, \"lang\": \"zh_CN\"}}}',
+            "新闻": '{\"function_call\": {\"name\": \"get_news\", \"arguments\": {\"category\": null, \"detail\": false, \"lang\": \"zh_CN\"}}}',
+            "财经新闻": '{\"function_call\": {\"name\": \"get_news\", \"arguments\": {\"category\": \"财经\", \"detail\": false, \"lang\": \"zh_CN\"}}}',
+            "国际新闻": '{\"function_call\": {\"name\": \"get_news\", \"arguments\": {\"category\": \"国际\", \"detail\": false, \"lang\": \"zh_CN\"}}}',
+            "社会新闻": '{\"function_call\": {\"name\": \"get_news\", \"arguments\": {\"category\": \"社会\", \"detail\": false, \"lang\": \"zh_CN\"}}}',
+            "详细介绍": '{\"function_call\": {\"name\": \"get_news\", \"arguments\": {\"detail\": true, \"lang\": \"zh_CN\"}}}',
+            "详情": '{\"function_call\": {\"name\": \"get_news\", \"arguments\": {\"detail\": true, \"lang\": \"zh_CN\"}}}',
+            "再见": '{\"intent\": \"结束聊天\"}',
+            "结束": '{\"intent\": \"结束聊天\"}',
+            "拜拜": '{\"intent\": \"结束聊天\"}',
+            "播放音乐": '{\"function_call\": {\"name\": \"play_music\", \"arguments\": {\"song_name\": \"random\"}}}'
+        }
 
     def get_intent_system_prompt(self) -> str:
         """
@@ -25,7 +45,9 @@ class IntentProvider(IntentProviderBase):
         """
         "continue_chat":    "1.继续聊天, 除了播放音乐和结束聊天的时候的选项, 比如日常的聊天和问候, 对话等",
         "end_chat":         "2.结束聊天, 用户发来如再见之类的表示结束的话, 不想再进行对话的时候",
-        "play_music":       "3.播放音乐, 用户希望你可以播放音乐, 只用于播放音乐的意图"
+        "play_music":       "3.播放音乐, 用户希望你可以播放音乐, 只用于播放音乐的意图",
+        "get_weather":      "4.查询天气, 用户希望查询某个地点的天气情况"
+        "get_news":         "5.查询新闻, 用户希望查询最新新闻或特定类型的新闻"
         """
         for key, value in self.intent_options.items():
             if key == "play_music":
@@ -34,50 +56,141 @@ class IntentProvider(IntentProviderBase):
                 intent_list.append("2.结束聊天, 用户发来如再见之类的表示结束的话, 不想再进行对话的时候")
             elif key == "continue_chat":
                 intent_list.append("1.继续聊天, 除了播放音乐和结束聊天的时候的选项, 比如日常的聊天和问候, 对话等")
+            elif key == "get_weather":
+                intent_list.append("4.查询天气, 用户希望查询某个地点的天气情况")
+            elif key == "get_news":
+                intent_list.append("5.查询新闻, 用户希望查询最新新闻或特定类型的新闻")
             else:
                 intent_list.append(value)
 
-        # "如果是唱歌、听歌、播放音乐，请指定歌名，格式为'播放音乐 [识别出的歌名]'。\n"
-        # "如果听不出具体歌名，可以返回'随机播放音乐'。\n"
-        # "只需要返回意图结果的json，不要解释。"
-        # "返回格式如下：\n"
         prompt = (
-            "你是一个意图识别助手。你需要根据和用户的对话记录，重点分析用户的最后一句话，判断用户意图属于以下哪一类(使用<start>和<end>标志)：\n"
+            "你是一个意图识别助手。请分析用户的最后一句话，判断用户意图属于以下哪一类：\n"
             "<start>"
             f"{', '.join(intent_list)}"
             "<end>\n"
-            "你需要按照以下的步骤处理用户的对话"
-            "1. 思考出对话的意图是哪一类的"
-            "2. 属于1和2的意图, 直接返回，返回格式如下：\n"
-            "{intent: '用户意图'}\n"
-            "3. 属于3的意图，则继续分析用户希望播放的音乐\n"
-            "4. 如果无法识别出具体歌名，可以返回'随机播放音乐'\n"
-            "{intent: '播放音乐 [获取的音乐名字]'}\n"
-            "下面是几个处理的示例(思考的内容不返回, 只返回json部分, 无额外的内容)\n"
-            "```"
+            "处理步骤:"
+            "1. 思考意图类型"
+            "2. 继续聊天和结束聊天意图: 返回intent格式"
+            "3. 播放音乐意图: 分析歌名，生成function_call格式"
+            "4. 查询天气意图: 分析地点，生成function_call格式"
+            "5. 查询新闻意图: 分析新闻类别，生成function_call格式"
+            "\n\n"
+            "返回格式示例：\n"
+            "1. 继续聊天意图: {\"intent\": \"继续聊天\"}\n"
+            "2. 结束聊天意图: {\"intent\": \"结束聊天\"}\n"
+            "3. 播放音乐意图: {\"function_call\": {\"name\": \"play_music\", \"arguments\": {\"song_name\": \"音乐名称\"}}}\n"
+            "4. 查询天气意图: {\"function_call\": {\"name\": \"get_weather\", \"arguments\": {\"location\": \"地点名称\", \"lang\": \"zh_CN\"}}}\n"
+            "5. 查询新闻意图: {\"function_call\": {\"name\": \"get_news\", \"arguments\": {\"category\": \"新闻类别\", \"detail\": false, \"lang\": \"zh_CN\"}}}\n"
+            "\n"
+            "注意:\n"
+            "- 播放音乐：无歌名时，song_name设为\"random\"\n"
+            "- 查询天气：无地点时，location设为null\n"
+            "- 查询新闻：无类别时，category设为null；查询详情时，detail设为true\n"
+            "- 只返回纯JSON，不要任何其他内容\n"
+            "\n"
+            "示例分析:\n"
+            "```\n"
             "用户: 你今天怎么样?\n"
-            "思考(不返回): 用户发来的数据是一个问候语，属于继续聊天的意图, 是种类1, 种类1的需求是直接返回\n"
-            "返回结果: {intent: '继续聊天'}\n"
-            "```"
-            "用户: 我今天有点累了, 我们明天再聊吧\n"
-            "思考(不返回): 用户表达了今天不想继续对话，属于结束聊天的意图, 是种类2, 种类2的需求是直接返回\n"
-            "返回结果: {intent: '结束聊天'}\n"
-            "```"
-            "用户: 我今天有点累了, 我们明天再聊吧\n"
-            "思考(不返回): 用户表达了今天不想继续对话，属于结束聊天的意图, 是种类2, 种类2的需求是直接返回\n"
-            "返回结果: {intent: '结束聊天'}\n"
-            "```"
-            "用户: 你可以播放一首中秋月给我听吗\n"
-            "思考(不返回): 用户表达了想听音乐的续签，属于播放音乐的意图, 是种类3, 种类3的需求需要继续判断播放的音乐, 这里用户希望的歌曲名明确给出是中秋月\n"
-            "返回结果: {intent: '播放音乐 [中秋月]'}\n"
-            "```"
-            "你现在可以使用的音乐的名称如下(使用<start>和<end>标志):\n"
+            "返回: {\"intent\": \"继续聊天\"}\n"
+            "```\n"
+            "```\n"
+            "用户: 我们明天再聊吧\n"
+            "返回: {\"intent\": \"结束聊天\"}\n"
+            "```\n"
+            "```\n"
+            "用户: 播放中秋月\n"
+            "返回: {\"function_call\": {\"name\": \"play_music\", \"arguments\": {\"song_name\": \"中秋月\"}}}\n"
+            "```\n"
+            "```\n"
+            "用户: 北京天气怎么样\n"
+            "返回: {\"function_call\": {\"name\": \"get_weather\", \"arguments\": {\"location\": \"北京\", \"lang\": \"zh_CN\"}}}\n"
+            "```\n"
+            "```\n"
+            "用户: 今天天气怎么样\n"
+            "返回: {\"function_call\": {\"name\": \"get_weather\", \"arguments\": {\"location\": null, \"lang\": \"zh_CN\"}}}\n"
+            "```\n"
+            "```\n"
+            "用户: 播报财经新闻\n"
+            "返回: {\"function_call\": {\"name\": \"get_news\", \"arguments\": {\"category\": \"财经\", \"detail\": false, \"lang\": \"zh_CN\"}}}\n"
+            "```\n"
+            "```\n"
+            "用户: 有什么最新新闻\n"
+            "返回: {\"function_call\": {\"name\": \"get_news\", \"arguments\": {\"category\": null, \"detail\": false, \"lang\": \"zh_CN\"}}}\n"
+            "```\n"
+            "```\n"
+            "用户: 详细介绍一下这条新闻\n"
+            "返回: {\"function_call\": {\"name\": \"get_news\", \"arguments\": {\"detail\": true, \"lang\": \"zh_CN\"}}}\n"
+            "```\n"
+            "可用的音乐名称:\n"
         )
         return prompt
+        
+    def clean_cache(self):
+        """清理过期缓存"""
+        now = time.time()
+        # 找出过期键
+        expired_keys = [k for k, v in self.intent_cache.items() if now - v['timestamp'] > self.cache_expiry]
+        for key in expired_keys:
+            del self.intent_cache[key]
+            
+        # 如果缓存太大，移除最旧的条目
+        if len(self.intent_cache) > self.cache_max_size:
+            # 按时间戳排序并保留最新的条目
+            sorted_items = sorted(self.intent_cache.items(), key=lambda x: x[1]['timestamp'])
+            for key, _ in sorted_items[:len(sorted_items) - self.cache_max_size]:
+                del self.intent_cache[key]
+
+    def check_pattern_match(self, text):
+        """检查文本是否匹配常见模式，并提取关键信息"""
+        # 城市+天气的特殊模式匹配
+        city_weather_pattern = re.search(r'([^\s,，。？！]+)天气', text)
+        if city_weather_pattern:
+            city = city_weather_pattern.group(1)
+            # 排除可能的误匹配，如"今天天气"、"明天天气"、"现在天气"等
+            if city not in ["今天", "今日", "明天", "现在", "当前", "未来", "明日", "这两天", "近期"]:
+                logger.bind(tag=TAG).info(f"提取到城市名: {city}")
+                # 返回包含城市名的function_call
+                return f'{{\"function_call\": {{\"name\": \"get_weather\", \"arguments\": {{\"location\": \"{city}\", \"lang\": \"zh_CN\"}}}}}}'
+        
+        # 普通模式匹配
+        for pattern, intent in self.common_patterns.items():
+            if pattern in text:
+                return intent
+                
+        return None
 
     async def detect_intent(self, conn, dialogue_history: List[Dict], text: str) -> str:
         if not self.llm:
             raise ValueError("LLM provider not set")
+            
+        # 记录整体开始时间
+        total_start_time = time.time()
+            
+        # 打印使用的模型信息
+        model_info = getattr(self.llm, 'model_name', str(self.llm.__class__.__name__))
+        logger.bind(tag=TAG).info(f"使用意图识别模型: {model_info}")
+            
+        # 先尝试简单的模式匹配
+        pattern_match = self.check_pattern_match(text)
+        if pattern_match:
+            pattern_time = time.time() - total_start_time
+            logger.bind(tag=TAG).info(f"模式匹配成功: {text} -> {pattern_match}, 耗时: {pattern_time:.4f}秒")
+            return pattern_match
+            
+        # 计算缓存键
+        cache_key = hashlib.md5(text.encode()).hexdigest()
+        
+        # 检查缓存
+        if cache_key in self.intent_cache:
+            cache_entry = self.intent_cache[cache_key]
+            # 检查缓存是否过期
+            if time.time() - cache_entry['timestamp'] <= self.cache_expiry:
+                cache_time = time.time() - total_start_time
+                logger.bind(tag=TAG).info(f"使用缓存的意图: {cache_key} -> {cache_entry['intent']}, 耗时: {cache_time:.4f}秒")
+                return cache_entry['intent']
+                
+        # 清理缓存
+        self.clean_cache()
 
         # 构建用户最后一句话的提示
         msgStr = ""
@@ -94,18 +207,78 @@ class IntentProvider(IntentProviderBase):
         music_file_names = music_config["music_file_names"]
         prompt_music = f"{self.promot}\n<start>{music_file_names}\n<end>"
         logger.bind(tag=TAG).debug(f"User prompt: {prompt_music}")
+        
+        # 记录预处理完成时间
+        preprocess_time = time.time() - total_start_time
+        logger.bind(tag=TAG).debug(f"意图识别预处理耗时: {preprocess_time:.4f}秒")
+        
         # 使用LLM进行意图识别
+        llm_start_time = time.time()
+        logger.bind(tag=TAG).info(f"开始LLM意图识别调用, 模型: {model_info}")
+        
         intent = self.llm.response_no_stream(
             system_prompt=prompt_music,
             user_prompt=user_prompt
         )
-        # 使用正则表达式提取大括号中的内容  
-        # 使用正则表达式提取 {} 中的内容
-        match = re.search(r'\{.*?\}', intent)
+        
+        # 记录LLM调用完成时间
+        llm_time = time.time() - llm_start_time
+        logger.bind(tag=TAG).info(f"LLM意图识别完成, 模型: {model_info}, 调用耗时: {llm_time:.4f}秒")
+        
+        # 记录后处理开始时间
+        postprocess_start_time = time.time()
+        
+        # 清理和解析响应
+        intent = intent.strip()
+        # 尝试提取JSON部分
+        match = re.search(r'\{.*\}', intent, re.DOTALL)
         if match:
-            result = match.group(0)
-            intent = result
-        else:
-            intent = "{intent: '继续聊天'}"
-        logger.bind(tag=TAG).info(f"Detected intent: {intent}")
-        return intent.strip()
+            intent = match.group(0)
+        
+        # 记录总处理时间
+        total_time = time.time() - total_start_time
+        logger.bind(tag=TAG).info(f"【意图识别性能】模型: {model_info}, 总耗时: {total_time:.4f}秒, LLM调用: {llm_time:.4f}秒, 查询: '{text[:20]}...'")
+        
+        # 尝试解析为JSON
+        try:
+            intent_data = json.loads(intent)
+            # 如果包含function_call，则格式化为适合处理的格式
+            if "function_call" in intent_data:
+                function_data = intent_data["function_call"]
+                function_name = function_data.get("name")
+                function_args = function_data.get("arguments", {})
+                
+                # 记录识别到的function call
+                logger.bind(tag=TAG).info(f"识别到function call: {function_name}, 参数: {function_args}")
+                
+                # 添加到缓存
+                self.intent_cache[cache_key] = {
+                    'intent': intent,
+                    'timestamp': time.time()
+                }
+                
+                # 后处理时间
+                postprocess_time = time.time() - postprocess_start_time
+                logger.bind(tag=TAG).debug(f"意图后处理耗时: {postprocess_time:.4f}秒")
+                
+                # 确保返回完全序列化的JSON字符串
+                return intent
+            else:
+                # 添加到缓存
+                self.intent_cache[cache_key] = {
+                    'intent': intent,
+                    'timestamp': time.time()
+                }
+                
+                # 后处理时间
+                postprocess_time = time.time() - postprocess_start_time
+                logger.bind(tag=TAG).debug(f"意图后处理耗时: {postprocess_time:.4f}秒")
+                
+                # 返回普通意图
+                return intent
+        except json.JSONDecodeError:
+            # 后处理时间
+            postprocess_time = time.time() - postprocess_start_time
+            logger.bind(tag=TAG).error(f"无法解析意图JSON: {intent}, 后处理耗时: {postprocess_time:.4f}秒")
+            # 如果解析失败，默认返回继续聊天意图
+            return "{\"intent\": \"继续聊天\"}"

--- a/main/xiaozhi-server/core/providers/llm/xinference/xinference.py
+++ b/main/xiaozhi-server/core/providers/llm/xinference/xinference.py
@@ -1,0 +1,85 @@
+from config.logger import setup_logging
+from openai import OpenAI
+import json
+from core.providers.llm.base import LLMProviderBase
+
+TAG = __name__
+logger = setup_logging()
+
+
+class LLMProvider(LLMProviderBase):
+    def __init__(self, config):
+        self.model_name = config.get("model_name")
+        self.base_url = config.get("base_url", "http://localhost:9997")
+        # Initialize OpenAI client with Xinference base URL
+        # 如果没有v1，增加v1
+        if not self.base_url.endswith("/v1"):
+            self.base_url = f"{self.base_url}/v1"
+            
+        logger.bind(tag=TAG).info(f"Initializing Xinference LLM provider with model: {self.model_name}, base_url: {self.base_url}")
+
+        try:
+            self.client = OpenAI(
+                base_url=self.base_url,
+                api_key="xinference"  # Xinference has a similar setup to Ollama where it doesn't need an actual key
+            )
+            logger.bind(tag=TAG).info("Xinference client initialized successfully")
+        except Exception as e:
+            logger.bind(tag=TAG).error(f"Error initializing Xinference client: {e}")
+            raise
+
+    def response(self, session_id, dialogue):
+        try:
+            logger.bind(tag=TAG).debug(f"Sending request to Xinference with model: {self.model_name}, dialogue length: {len(dialogue)}")
+            responses = self.client.chat.completions.create(
+                model=self.model_name,
+                messages=dialogue,
+                stream=True
+            )
+            is_active=True
+            for chunk in responses:
+                try:
+                    delta = chunk.choices[0].delta if getattr(chunk, 'choices', None) else None
+                    content = delta.content if hasattr(delta, 'content') else ''
+                    if content:
+                        if '<think>' in content:
+                            is_active = False
+                            content = content.split('<think>')[0]
+                        if '</think>' in content:
+                            is_active = True
+                            content = content.split('</think>')[-1]
+                        if is_active:
+                            yield content
+                except Exception as e:
+                    logger.bind(tag=TAG).error(f"Error processing chunk: {e}")
+
+        except Exception as e:
+            logger.bind(tag=TAG).error(f"Error in Xinference response generation: {e}")
+            yield "【Xinference服务响应异常】"
+
+    def response_with_functions(self, session_id, dialogue, functions=None):
+        try:
+            logger.bind(tag=TAG).debug(f"Sending function call request to Xinference with model: {self.model_name}, dialogue length: {len(dialogue)}")
+            if functions:
+                logger.bind(tag=TAG).debug(f"Function calls enabled with: {[f.get('function', {}).get('name') for f in functions]}")
+                
+            stream = self.client.chat.completions.create(
+                model=self.model_name,
+                messages=dialogue,
+                stream=True,
+                tools=functions,
+            )
+
+            for chunk in stream:
+                delta = chunk.choices[0].delta
+                content = delta.content
+                tool_calls = delta.tool_calls
+                
+                if content:
+                    yield content, tool_calls
+                elif tool_calls:
+                    yield None, tool_calls
+
+        except Exception as e:
+            logger.bind(tag=TAG).error(f"Error in Xinference function call: {e}")
+            yield {"type": "content", "content": f"【Xinference服务响应异常: {str(e)}】"} 

--- a/main/xiaozhi-server/plugins_func/functions/get_weather.py
+++ b/main/xiaozhi-server/plugins_func/functions/get_weather.py
@@ -2,6 +2,7 @@ import requests
 from bs4 import BeautifulSoup
 from config.logger import setup_logging
 from plugins_func.register import register_function, ToolType, ActionResponse, Action
+import json
 
 TAG = __name__
 logger = setup_logging()
@@ -39,85 +40,158 @@ HEADERS = {
     )
 }
 
-# 天气代码 https://dev.qweather.com/docs/resource/icons/#weather-icons
-WEATHER_CODE_MAP = {
-    "100": "晴", "101": "多云", "102": "少云", "103": "晴间多云", "104": "阴",
-    "150": "晴", "151": "多云", "152": "少云", "153": "晴间多云",
-    "300": "阵雨", "301": "强阵雨", "302": "雷阵雨", "303": "强雷阵雨", "304": "雷阵雨伴有冰雹",
-    "305": "小雨", "306": "中雨", "307": "大雨", "308": "极端降雨", "309": "毛毛雨/细雨",
-    "310": "暴雨", "311": "大暴雨", "312": "特大暴雨", "313": "冻雨", "314": "小到中雨",
-    "315": "中到大雨", "316": "大到暴雨", "317": "暴雨到大暴雨", "318": "大暴雨到特大暴雨",
-    "350": "阵雨", "351": "强阵雨", "399": "雨",
-    "400": "小雪", "401": "中雪", "402": "大雪", "403": "暴雪", "404": "雨夹雪",
-    "405": "雨雪天气", "406": "阵雨夹雪", "407": "阵雪", "408": "小到中雪", "409": "中到大雪", "410": "大到暴雪",
-    "456": "阵雨夹雪", "457": "阵雪", "499": "雪",
-    "500": "薄雾", "501": "雾", "502": "霾", "503": "扬沙", "504": "浮尘",
-    "507": "沙尘暴", "508": "强沙尘暴", 
-    "509": "浓雾", "510": "强浓雾", "511": "中度霾", "512": "重度霾", "513": "严重霾", "514": "大雾", "515": "特强浓雾",
-    "900": "热", "901": "冷", "999": "未知"
-}
 
 def fetch_city_info(location, api_key):
     url = f"https://geoapi.qweather.com/v2/city/lookup?key={api_key}&location={location}&lang=zh"
-    response = requests.get(url, headers=HEADERS).json()
-    return response.get('location', [])[0] if response.get('location') else None
+    logger.bind(tag=TAG).info(f"正在请求城市信息API，URL: {url}")
+    try:
+        response = requests.get(url, headers=HEADERS)
+        logger.bind(tag=TAG).info(f"城市信息API响应状态码: {response.status_code}")
+        json_data = response.json()
+        logger.bind(tag=TAG).debug(f"城市信息API响应: {json.dumps(json_data, ensure_ascii=False)}")
+        return json_data.get('location', [])[0] if json_data.get('location') else None
+    except Exception as e:
+        logger.bind(tag=TAG).error(f"获取城市信息失败: {str(e)}")
+        return None
 
 
 def fetch_weather_page(url):
-    response = requests.get(url, headers=HEADERS)
-    return BeautifulSoup(response.text, "html.parser") if response.ok else None
+    logger.bind(tag=TAG).info(f"正在请求天气页面，URL: {url}")
+    try:
+        response = requests.get(url, headers=HEADERS)
+        logger.bind(tag=TAG).info(f"天气页面响应状态码: {response.status_code}")
+        if not response.ok:
+            logger.bind(tag=TAG).error(f"获取天气页面失败: {response.text[:200]}")
+        return BeautifulSoup(response.text, "html.parser") if response.ok else None
+    except Exception as e:
+        logger.bind(tag=TAG).error(f"获取天气页面失败: {str(e)}")
+        return None
 
 
 def parse_weather_info(soup):
-    city_name = soup.select_one("h1.c-submenu__location").get_text(strip=True)
+    try:
+        city_name = soup.select_one("h1.c-submenu__location").get_text(strip=True)
+        logger.bind(tag=TAG).info(f"解析到城市名称: {city_name}")
 
-    current_abstract = soup.select_one(".c-city-weather-current .current-abstract")
-    current_abstract = current_abstract.get_text(strip=True) if current_abstract else "未知"
+        current_abstract = soup.select_one(".c-city-weather-current .current-abstract")
+        current_abstract = current_abstract.get_text(strip=True) if current_abstract else "未知"
+        logger.bind(tag=TAG).info(f"当前天气概况: {current_abstract}")
 
-    current_basic = {}
-    for item in soup.select(".c-city-weather-current .current-basic .current-basic___item"):
-        parts = item.get_text(strip=True, separator=" ").split(" ")
-        if len(parts) == 2:
-            key, value = parts[1], parts[0]
-            current_basic[key] = value
+        current_basic = {}
+        for item in soup.select(".c-city-weather-current .current-basic .current-basic___item"):
+            parts = item.get_text(strip=True, separator=" ").split(" ")
+            if len(parts) == 2:
+                key, value = parts[1], parts[0]
+                current_basic[key] = value
+        logger.bind(tag=TAG).info(f"当前天气详情: {json.dumps(current_basic, ensure_ascii=False)}")
 
-    temps_list = []
-    for row in soup.select(".city-forecast-tabs__row")[:7]:  # 取前7天的数据
-        date = row.select_one(".date-bg .date").get_text(strip=True)
-        weather_code = row.select_one(".date-bg .icon")["src"].split("/")[-1].split(".")[0]
-        weather = WEATHER_CODE_MAP.get(weather_code, "未知")
-        temps = [span.get_text(strip=True) for span in row.select(".tmp-cont .temp")]
-        high_temp, low_temp = (temps[0], temps[-1]) if len(temps) >= 2 else (None, None)
-        temps_list.append((date, weather, high_temp, low_temp))
+        temps_list = []
+        for row in soup.select(".city-forecast-tabs__row")[:7]:  # 取前7天的数据
+            date = row.select_one(".date-bg .date").get_text(strip=True)
+            temps = [span.get_text(strip=True) for span in row.select(".tmp-cont .temp")]
+            high_temp, low_temp = (temps[0], temps[-1]) if len(temps) >= 2 else (None, None)
+            temps_list.append((date, high_temp, low_temp))
+        logger.bind(tag=TAG).info(f"获取到未来7天温度: {temps_list}")
 
-    return city_name, current_abstract, current_basic, temps_list
+        return city_name, current_abstract, current_basic, temps_list
+    except Exception as e:
+        logger.bind(tag=TAG).error(f"解析天气信息失败: {str(e)}")
+        return "未知城市", "未知天气", {}, []
 
 
 @register_function('get_weather', GET_WEATHER_FUNCTION_DESC, ToolType.SYSTEM_CTL)
 def get_weather(conn, location: str = None, lang: str = "zh_CN"):
-    api_key = conn.config["plugins"]["get_weather"]["api_key"]
-    default_location = conn.config["plugins"]["get_weather"]["default_location"]
-    location = location or conn.client_ip_info.get("city") or default_location
-    logger.bind(tag=TAG).debug(f"获取天气: {location}")
+    logger.bind(tag=TAG).info(f"===== 天气查询函数开始执行 =====")
+    logger.bind(tag=TAG).info(f"查询参数: location={location}, lang={lang}")
+    
+    try:
+        api_key = conn.config["plugins"]["get_weather"]["api_key"]
+        default_location = conn.config["plugins"]["get_weather"]["default_location"]
+        
+        # 位置参数处理逻辑优化
+        # 1. 如果传入了明确的位置参数且不为None/空字符串，则使用该参数
+        # 2. 否则，尝试使用客户端IP地址对应的城市信息
+        # 3. 如果上述都无效，则使用配置文件中的默认位置
+        if location and location.strip():
+            final_location = location.strip()
+            logger.bind(tag=TAG).info(f"使用用户明确指定的位置: {final_location}")
+        elif conn.client_ip_info and "city" in conn.client_ip_info and conn.client_ip_info["city"]:
+            final_location = conn.client_ip_info["city"]
+            logger.bind(tag=TAG).info(f"使用IP地址解析的位置: {final_location}")
+        else:
+            final_location = default_location
+            logger.bind(tag=TAG).info(f"使用配置文件中的默认位置: {final_location}")
+            
+        logger.bind(tag=TAG).info(f"最终使用的查询地点: {final_location}, API Key: {api_key}")
 
-    city_info = fetch_city_info(location, api_key)
-    if not city_info:
-        return ActionResponse(Action.REQLLM, f"未找到相关的城市: {location}，请确认地点是否正确", None)
+        city_info = fetch_city_info(final_location, api_key)
+        if not city_info:
+            error_msg = f"未找到相关的城市: {final_location}，请确认地点是否正确"
+            logger.bind(tag=TAG).error(error_msg)
+            # 构造一个直接回复
+            direct_response = f"抱歉，我未能找到\"{final_location}\"的天气信息，请确认地点名称是否正确，或者尝试查询其他城市的天气。"
+            return ActionResponse(Action.RESPONSE, None, direct_response)  # 使用RESPONSE动作直接返回
 
-    soup = fetch_weather_page(city_info['fxLink'])
-    if not soup:
-        return ActionResponse(Action.REQLLM, None, "请求失败")
+        logger.bind(tag=TAG).info(f"获取到城市信息: {json.dumps(city_info, ensure_ascii=False)}")
+        logger.bind(tag=TAG).info(f"天气查询链接: {city_info['fxLink']}")
+        
+        soup = fetch_weather_page(city_info['fxLink'])
+        if not soup:
+            error_msg = "请求天气页面失败"
+            logger.bind(tag=TAG).error(error_msg)
+            direct_response = f"抱歉，在获取{final_location}的天气信息时遇到了问题，请稍后再试。"
+            return ActionResponse(Action.RESPONSE, None, direct_response)  # 使用RESPONSE动作直接返回
 
-    city_name, current_abstract, current_basic, temps_list = parse_weather_info(soup)
-    weather_report = f"根据下列数据，用{lang}回应用户的查询天气请求：\n{city_name}未来7天天气:\n"
-    for i, (date, weather, high, low) in enumerate(temps_list):
-        if high and low:
-            weather_report += f"{date}: {low}到{high}, {weather}\n"
-    weather_report += (
-        f"当前天气: {current_abstract}\n"
-        f"当前天气参数: {current_basic}\n"
-        f"(确保只报告指定单日的天气情况，除非未来会出现异常天气；或者用户明确要求想要了解多日天气，如果未指定，默认报告今天的天气。"
-        "参数为0的值不需要报告给用户，每次都报告体感温度，根据语境选择合适的参数内容告知用户，并对参数给出相应评价)"
-    )
-
-    return ActionResponse(Action.REQLLM, weather_report, None)
+        city_name, current_abstract, current_basic, temps_list = parse_weather_info(soup)
+        
+        # 构建天气报告（给LLM使用的详细数据）
+        weather_report = f"根据下列数据，用{lang}回应用户的查询天气请求：\n{city_name}未来7天天气:\n"
+        for i, (date, high, low) in enumerate(temps_list):
+            if high and low:
+                weather_report += f"{date}: {low}到{high}\n"
+        weather_report += (
+            f"当前天气: {current_abstract}\n"
+            f"当前天气参数: {current_basic}\n"
+            f"(确保只报告指定单日的气温范围，除非用户明确要求想要了解多日天气，如果未指定，默认报告今天的温度范围。"
+            "参数为0的值不需要报告给用户，每次都报告体感温度，根据语境选择合适的参数内容告知用户，并对参数给出相应评价)"
+        )
+        
+        # 同时构建一个直接可用的人性化天气回复
+        # 这用作备用，防止LLM处理失败时能够直接回复用户
+        today_temp = ""
+        for date, high, low in temps_list:
+            if "今天" in date or "今日" in date:
+                today_temp = f"{low}到{high}"
+                break
+        if not today_temp and temps_list:
+            today_temp = f"{temps_list[0][2]}到{temps_list[0][1]}"
+        
+        feel_temp = current_basic.get("体感温度", "")
+        humidity = current_basic.get("相对湿度", "")
+        
+        direct_response = f"{city_name}今天{current_abstract}，温度{today_temp}。"
+        if feel_temp:
+            direct_response += f"体感温度{feel_temp}。"
+        if humidity:
+            direct_response += f"相对湿度{humidity}。"
+            
+        # 添加简单的建议
+        if "雨" in current_abstract:
+            direct_response += "外出请记得带伞。"
+        elif temps_list and temps_list[0][1] and int(temps_list[0][1].replace("°", "")) > 30:
+            direct_response += "天气炎热，注意防暑。"
+        elif temps_list and temps_list[0][2] and int(temps_list[0][2].replace("°", "")) < 10:
+            direct_response += "天气较冷，注意保暖。"
+        
+        logger.bind(tag=TAG).info(f"构建的天气报告: {weather_report}")
+        logger.bind(tag=TAG).info(f"备用直接回复: {direct_response}")
+        logger.bind(tag=TAG).info(f"===== 天气查询函数执行完毕，返回结果 =====")
+        
+        # 返回详细天气报告，但添加direct_response作为备用
+        return ActionResponse(Action.REQLLM, weather_report, direct_response)
+    except Exception as e:
+        error_msg = f"查询天气时发生错误: {str(e)}"
+        logger.bind(tag=TAG).error(error_msg)
+        # 出错时也提供一个直接回复
+        direct_response = f"抱歉，在获取天气信息时遇到了技术问题，请稍后再试。"
+        return ActionResponse(Action.RESPONSE, None, direct_response)  # 使用RESPONSE动作直接返回


### PR DESCRIPTION
1，为意图识别intent_llm单独配置独立的LLM，可在.config.yaml中的IntentLLM根据需求自行配置，我的代码中是使用的本地部署的xinference。
2，为意图识别intent_llm增加了天气和新闻查询功能，主要修改了intent_llm.py，base.py，connection.py，intentHandler.py几个文件中相关的代码
3，根据个人需要，添加了xinference作为LLM