### PR TITLE
edge-tts 流式写

### DIFF
--- a/main/xiaozhi-server/core/providers/tts/edge.py
+++ b/main/xiaozhi-server/core/providers/tts/edge.py
@@ -14,5 +14,14 @@ class TTSProvider(TTSProviderBase):
         return os.path.join(self.output_file, f"tts-{datetime.now().date()}@{uuid.uuid4().hex}{extension}")
 
     async def text_to_speak(self, text, output_file):
-        communicate = edge_tts.Communicate(text, voice=self.voice)  # Use your preferred voice
-        await communicate.save(output_file)
+        communicate = edge_tts.Communicate(text, voice=self.voice)
+        # 确保目录存在并创建空文件
+        os.makedirs(os.path.dirname(output_file), exist_ok=True)
+        with open(output_file, 'wb') as f:
+            pass
+        
+        # 流式写入音频数据
+        with open(output_file, 'ab') as f:  # 改为追加模式避免覆盖
+            async for chunk in communicate.stream():
+                if chunk["type"] == "audio":  # 只处理音频数据块
+                    f.write(chunk["data"])


### PR DESCRIPTION
避免一次性加载完整语音到内存，无需等待完整音频生成再保存，音频数据块（chunk）生成后立即写入文件，相比等待完整音频生成后再保存，能更早得到部分结果，当生成过程意外中断时，通过追加模式 ab 保证，已生成的音频片段不会丢失，if chunk["type"] == "audio" 的过滤逻辑确保只写入有效音频数据，避免混杂其他类型的元数据