### PR TITLE
将 mysql redis 服务放入 docker-compose.yml 降低环境配置成本

### DIFF
--- a/main/xiaozhi-server/docker-compose.yml
+++ b/main/xiaozhi-server/docker-compose.yml
@@ -1,8 +1,3 @@
-# 如果本机已经安装了MySQL，可以直接在数据库中创建名为`xiaozhi_esp32_server`的数据库。
-# 如果还没有MySQL，你可以通过docker安装mysql,执行以下一句话
-# docker run --name xiaozhi-esp32-server-db -e MYSQL_ROOT_PASSWORD=123456 -p 3306:3306 -e MYSQL_DATABASE=xiaozhi_esp32_server -e MYSQL_INITDB_ARGS="--character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci" -d mysql:latest
-# 如果你的mysql账号和密码有修改过，记得修改下方数据库的账号和密码
-# 记得修改下方数据库的IP，ip不能写127.0.0.1或localhost，否则容器无法访问，要写你电脑局域网ip
 version: '3'
 services:
   xiaozhi-esp32-server:
@@ -22,18 +17,29 @@ services:
       # 模型文件挂接，很重要
       - ./models/SenseVoiceSmall/model.pt:/opt/xiaozhi-esp32-server/models/SenseVoiceSmall/model.pt
 
-#  #智控台还没开发好，还不能完全使用，会报很多错误，如果是非技术人员，请不要启用智控台服务
-#  xiaozhi-esp32-server-web:
-#    image: ghcr.nju.edu.cn/xinnan-tech/xiaozhi-esp32-server:web_latest
-#    container_name: xiaozhi-esp32-server-web
-#    restart: always
-#    ports:
-#      - "8002:8002"
-#    environment:
-#      - TZ=Asia/Shanghai
-#      ##记得改mysql和redis IP 密码
-#      - SPRING_DATASOURCE_DRUID_URL=jdbc:mysql://192.168.1.20:3306/xiaozhi_esp32_server?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Shanghai
-#      - SPRING_DATASOURCE_DRUID_USERNAME=root
-#      - SPRING_DATASOURCE_DRUID_PASSWORD=123456
-#      - SPRING_DATA_REDIS_HOST=192.168.1.20
-#      - SPRING_DATA_REDIS_PORT=6379
+  xiaozhi-esp32-server-db:
+    image: mysql:latest
+    container_name: xiaozhi-esp32-server-db
+    environment:
+      MYSQL_ROOT_PASSWORD: 123456
+      MYSQL_DATABASE: xiaozhi_esp32_server
+      MYSQL_INITDB_ARGS: "--character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci"
+    deploy:
+      restart_policy:
+        condition: any # This will restart the container on any exit condition, similar to the '-d' option.
+
+  # 注意：智控台还没开发好，还不能完全使用，会报很多错误。当前仅作为技术人员修复缺陷改善软件之用。
+  xiaozhi-esp32-server-web:
+    image: ghcr.nju.edu.cn/xinnan-tech/xiaozhi-esp32-server:web_latest
+    container_name: xiaozhi-esp32-server-web
+    restart: always
+    ports:
+      - "8002:8002"
+    environment:
+      - TZ=Asia/Shanghai
+      ## 如果你使用自己配置的 mysql/redis 服务，请相应修改下列 mysql url、redis IP 和 密码
+      - SPRING_DATASOURCE_DRUID_URL=jdbc:mysql://xiaozhi-esp32-server-db:3306/xiaozhi_esp32_server?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Shanghai
+      - SPRING_DATASOURCE_DRUID_USERNAME=root
+      - SPRING_DATASOURCE_DRUID_PASSWORD=123456
+      - SPRING_DATA_REDIS_HOST=xiaozhi-esp32-server-db
+      - SPRING_DATA_REDIS_PORT=6379


### PR DESCRIPTION
1. 将 mysql redis 放入 docker compose 中统一编排，降低开发时环境配置成本。
2. 默认将 web 服务开启，方便其他开发者进来一起完善功能，对普通用户（非开发者）不造成使用障碍。