### PR TITLE
WebSocket log info fix

### DIFF
--- a/main/xiaozhi-server/core/utils/util.py
+++ b/main/xiaozhi-server/core/utils/util.py
@@ -23,12 +23,6 @@ def get_local_ip():
         return local_ip
     except Exception as e:
         return "127.0.0.1"
-    
-def get_public_ip():
-    try:
-        return requests.get("https://api.ipify.org", timeout=2).text
-    except Exception as e:
-        return "unknown"
 
 def is_private_ip(ip_addr):
     """

--- a/main/xiaozhi-server/core/utils/util.py
+++ b/main/xiaozhi-server/core/utils/util.py
@@ -23,6 +23,12 @@ def get_local_ip():
         return local_ip
     except Exception as e:
         return "127.0.0.1"
+    
+def get_public_ip():
+    try:
+        return requests.get("https://api.ipify.org", timeout=2).text
+    except Exception as e:
+        return "unknown"
 
 def is_private_ip(ip_addr):
     """

--- a/main/xiaozhi-server/core/websocket_server.py
+++ b/main/xiaozhi-server/core/websocket_server.py
@@ -1,10 +1,8 @@
 import asyncio
 import websockets
-import requests
 from config.logger import setup_logging
 from core.connection import ConnectionHandler
 from core.utils.util import get_local_ip
-from core.utils.util import get_public_ip
 from core.utils import asr, vad, llm, tts, memory, intent
 
 TAG = __name__
@@ -60,7 +58,6 @@ class WebSocketServer:
                 self.config["Intent"][self.config["selected_module"]["Intent"]]
             ),
         )
-    
 
     async def start(self):
         server_config = self.config["server"]
@@ -69,11 +66,7 @@ class WebSocketServer:
         selected_module = self.config.get("selected_module")
         self.logger.bind(tag=TAG).info(f"selected_module values: {', '.join(selected_module.values())}")
 
-        public_ip = get_public_ip()  # 获取公共 IP
-        local_ip = get_local_ip() # 获取本地 IP
-
-        self.logger.bind(tag=TAG).info("Server is running locally at ws://{}:{}", local_ip, port)
-        self.logger.bind(tag=TAG).info("Server is running publicly at ws://{}:{}", public_ip, port)
+        self.logger.bind(tag=TAG).info("Server is running at ws://{}:{}", get_local_ip(), port)
         self.logger.bind(tag=TAG).info("=======上面的地址是websocket协议地址，请勿用浏览器访问=======")
         async with websockets.serve(
                 self._handle_connection,

--- a/main/xiaozhi-server/core/websocket_server.py
+++ b/main/xiaozhi-server/core/websocket_server.py
@@ -3,6 +3,7 @@ import websockets
 from config.logger import setup_logging
 from core.connection import ConnectionHandler
 from core.utils.util import get_local_ip
+from core.utils.util import get_public_ip
 from core.utils import asr, vad, llm, tts, memory, intent
 
 TAG = __name__
@@ -66,7 +67,8 @@ class WebSocketServer:
         selected_module = self.config.get("selected_module")
         self.logger.bind(tag=TAG).info(f"selected_module values: {', '.join(selected_module.values())}")
 
-        self.logger.bind(tag=TAG).info("Server is running at ws://{}:{}", get_local_ip(), port)
+        self.logger.bind(tag=TAG).info("Server is running locally at ws://{}:{}",get_local_ip(), port)
+        self.logger.bind(tag=TAG).info("Server is running publicly at ws://{}:{}", get_public_ip(), port)
         self.logger.bind(tag=TAG).info("=======上面的地址是websocket协议地址，请勿用浏览器访问=======")
         async with websockets.serve(
                 self._handle_connection,

--- a/main/xiaozhi-server/core/websocket_server.py
+++ b/main/xiaozhi-server/core/websocket_server.py
@@ -1,8 +1,10 @@
 import asyncio
 import websockets
+import requests
 from config.logger import setup_logging
 from core.connection import ConnectionHandler
 from core.utils.util import get_local_ip
+from core.utils.util import get_public_ip
 from core.utils import asr, vad, llm, tts, memory, intent
 
 TAG = __name__
@@ -58,6 +60,7 @@ class WebSocketServer:
                 self.config["Intent"][self.config["selected_module"]["Intent"]]
             ),
         )
+    
 
     async def start(self):
         server_config = self.config["server"]
@@ -66,7 +69,11 @@ class WebSocketServer:
         selected_module = self.config.get("selected_module")
         self.logger.bind(tag=TAG).info(f"selected_module values: {', '.join(selected_module.values())}")
 
-        self.logger.bind(tag=TAG).info("Server is running at ws://{}:{}", get_local_ip(), port)
+        public_ip = get_public_ip()  # 获取公共 IP
+        local_ip = get_local_ip() # 获取本地 IP
+
+        self.logger.bind(tag=TAG).info("Server is running locally at ws://{}:{}", local_ip, port)
+        self.logger.bind(tag=TAG).info("Server is running publicly at ws://{}:{}", public_ip, port)
         self.logger.bind(tag=TAG).info("=======上面的地址是websocket协议地址，请勿用浏览器访问=======")
         async with websockets.serve(
                 self._handle_connection,


### PR DESCRIPTION
add: implement get_public_ip function and log public IP in WebSocket server
For those who implement the service on the cloud, this should show the public IP in the log.