### PR TITLE
fix:修复handle_device.py 参数类型定义错误导致DoubaoLLM调用报 400 错误

### DIFF
--- a/main/xiaozhi-server/plugins_func/functions/handle_device.py
+++ b/main/xiaozhi-server/plugins_func/functions/handle_device.py
@@ -69,7 +69,7 @@ handle_device_function_desc = {
                     "description": "动作名称，可选值：get(获取),set(设置),raise(提高),lower(降低)"
                 },
                 "value": {
-                    "type": "int",
+                    "type": "number",
                     "description": "值大小，可选值：0-100之间的整数"
                 }
             },


### PR DESCRIPTION
#555 