### PR TITLE
修复function call的参数类型定义错误

### DIFF
--- a/main/xiaozhi-server/plugins_func/functions/handle_device.py
+++ b/main/xiaozhi-server/plugins_func/functions/handle_device.py
@@ -69,7 +69,7 @@ handle_device_function_desc = {
                     "description": "动作名称，可选值：get(获取),set(设置),raise(提高),lower(降低)"
                 },
                 "value": {
-                    "type": "number",
+                    "type": "integer",
                     "description": "值大小，可选值：0-100之间的整数"
                 }
             },

--- a/main/xiaozhi-server/plugins_func/functions/hass_set_state.py
+++ b/main/xiaozhi-server/plugins_func/functions/hass_set_state.py
@@ -23,7 +23,7 @@ hass_set_state_function_desc = {
                             "description": "需要操作的动作,打开设备:turn_on,关闭设备:turn_off,增加亮度:brightness_up,降低亮度:brightness_down,设置亮度:brightness_value,增加>音量:,volume_up降低音量:volume_down,设置音量:volume_set,设备暂停:pause,设备继续:continue,静音/取消静音:volume_mute"
                         },
                         "input": {
-                            "type": "int",
+                            "type": "integer",
                             "description": "只有在设置音量,设置亮度时候才需要,有效值为1-100,对应音量和亮度的1%-100%"
                         },
                         "is_muted": {


### PR DESCRIPTION
上个pr #562 遗漏了hass_set_state.py，并且number 类型改为integer 更加准确一点