### PR TITLE
get_ip_info接口优化

### DIFF
--- a/main/xiaozhi-server/core/utils/util.py
+++ b/main/xiaozhi-server/core/utils/util.py
@@ -67,13 +67,11 @@ def is_private_ip(ip_addr):
 
 def get_ip_info(ip_addr):
     try:
-        base_url = "https://freeipapi.com/api/json"
-        url = base_url if is_private_ip(ip_addr) else f"{base_url}/{ip_addr}"
-
+        url = "https://whois.pconline.com.cn/ipJson.jsp?json=true"
         resp = requests.get(url).json()
 
         ip_info = {
-            "city": resp.get("cityName")
+            "city": resp.get("city")
         }
         return ip_info
     except Exception as e:


### PR DESCRIPTION
freeipapi.com接口在部分地区无法访问获取bug修改
将失效的https://freeipapi.com/api/json替换为https://whois.pconline.com.cn/ipJson.jsp?json=true
#513 