### PR TITLE
为xiaozhi-server的requirments.txt文件添加PySocks包

### DIFF
--- a/main/xiaozhi-server/requirements.txt
+++ b/main/xiaozhi-server/requirements.txt
@@ -24,3 +24,4 @@ modelscope==1.23.2
 sherpa_onnx==1.11.0
 mcp==1.4.1
 cnlunar==0.2.0
+PySocks==1.7.1


### PR DESCRIPTION
### 原因 
requests 经过socks代理访问网络的时候需要依赖第三方package，对应PySocks包。否则会出现"Missing dependencies for SOCKSsupport."错误。
### 参考连接 
https://requests.readthedocs.io/en/latest/user/advanced/#socks