### PR TITLE
[docker] 更新了 docker-compose 

### DIFF
--- a/docs/Deployment_all.md
+++ b/docs/Deployment_all.md
@@ -106,7 +106,7 @@ docker run --name xiaozhi-esp32-server-redis -d -p 6379:6379 redis
 接下来打开命令行工具，使用`终端`或`命令行`工具 进入到你的`xiaozhi-server`，执行以下命令
 
 ```
-docker-compose -f docker-compose_all.yml up -d
+docker compose -f docker-compose_all.yml up -d
 ```
 
 执行完后，再执行以下命令，查看日志信息。

--- a/docs/Deployment_all.md
+++ b/docs/Deployment_all.md
@@ -71,7 +71,7 @@ xiaozhi-server
 
 如果你的文件目录结构也是上面的，就继续往下。如果不是，你就再仔细看看是不是漏操作了什么。
 
-## 2. 安装Mysql和Redis（可选）
+## 2. 手动安装Mysql和Redis（可选）
 
 ### 2.1 安装Mysql数据库
 如果本机已经安装了MySQL，可以直接在数据库中创建名为`xiaozhi_esp32_server`的数据库。然后把 docker-compose.yml 文件中的 xiaozhi-esp32-server-db 部分注释或者删除掉，同时修改 `jdbc:mysql://xiaozhi-esp32-server-db:3306/xiaozhi_esp32_server?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Shanghai` xiaozhi-esp32-server-db 为自己的局域网 IP 地址。
@@ -80,8 +80,7 @@ xiaozhi-server
 CREATE DATABASE xiaozhi_esp32_server CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ```
 
-### 2.2 安装Redis（可选）
-
+### 2.2 安装Redis
 如果还没有Redis，你可以通过docker安装redis
 
 ```

--- a/docs/Deployment_all.md
+++ b/docs/Deployment_all.md
@@ -71,22 +71,16 @@ xiaozhi-server
 
 如果你的文件目录结构也是上面的，就继续往下。如果不是，你就再仔细看看是不是漏操作了什么。
 
-## 2. 安装Mysql和Redis
+## 2. 安装Mysql和Redis（可选）
 
 ### 2.1 安装Mysql数据库
-如果本机已经安装了MySQL，可以直接在数据库中创建名为`xiaozhi_esp32_server`的数据库。
+如果本机已经安装了MySQL，可以直接在数据库中创建名为`xiaozhi_esp32_server`的数据库。然后把 docker-compose.yml 文件中的 xiaozhi-esp32-server-db 部分注释或者删除掉，同时修改 `jdbc:mysql://xiaozhi-esp32-server-db:3306/xiaozhi_esp32_server?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Shanghai` xiaozhi-esp32-server-db 为自己的局域网 IP 地址。
 
 ```sql
 CREATE DATABASE xiaozhi_esp32_server CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ```
 
-如果还没有MySQL，你可以通过docker安装mysql
-
-```
-docker run --name xiaozhi-esp32-server-db -e MYSQL_ROOT_PASSWORD=123456 -p 3306:3306 -e MYSQL_DATABASE=xiaozhi_esp32_server -e MYSQL_INITDB_ARGS="--character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci" -d mysql:latest
-```
-
-### 2.2 安装Redis
+### 2.2 安装Redis（可选）
 
 如果还没有Redis，你可以通过docker安装redis
 
@@ -94,7 +88,7 @@ docker run --name xiaozhi-esp32-server-db -e MYSQL_ROOT_PASSWORD=123456 -p 3306:
 docker run --name xiaozhi-esp32-server-redis -d -p 6379:6379 redis
 ```
 
-## 3. 配置docker-compose_all.yml文件文件
+### 2.3 配置docker-compose_all.yml文件使用本地的 MySQL 与 Redis
 
 在`xiaozhi-server`目录，打开docker-compose_all.yml，
 
@@ -104,19 +98,11 @@ docker run --name xiaozhi-esp32-server-redis -d -p 6379:6379 redis
 
 3、确认一下mysql的用户名`SPRING_DATASOURCE_DRUID_USERNAME`和密码`SPRING_DATASOURCE_DRUID_PASSWORD`
 
+## 3 配置docker-compose_all.yml（可选）
+
+你可以修改配置文件中的数据库密码环境变量 `SPRING_DATASOURCE_DRUID_PASSWORD` 与 `MYSQL_ROOT_PASSWORD` 为强密码。
+
 ## 4. 运行程序
-
-确认mysql和redis是否运行正常，输入
-```
-docker ps
-```
-如果你能看到`xiaozhi-esp32-server-redis`和`xiaozhi-esp32-server-db`信息，就可以继续往下，如果看不到，说明你的`mysql`和`redis`没有安装或没有启动。需要继续回到上面的教程，看看哪一步漏了。
-
-```
-CONTAINER ID             IMAGE   COMMAND   CREATED  TATUS   PORTS               NAMES
-xxx       redis          "xx"   xxx   xxx   0.0.0.0:6379->6379/tcp              xiaozhi-esp32-server-redis
-xxx       mysql:latest   "xx"   xxx   xxx   0.0.0.0:3306->3306/tcp, 33060/tcp   xiaozhi-esp32-server-db
-```
 
 接下来打开命令行工具，使用`终端`或`命令行`工具 进入到你的`xiaozhi-server`，执行以下命令
 
@@ -154,17 +140,15 @@ http://localhost:8002/xiaozhi/doc.html
 
 ```
 manager-api:
-  url: http://127.0.0.1:8002/xiaozhi
+  url: http://xiaozhi-esp32-server-web:8002/xiaozhi
   secret: 你的server.secret值
 ```
 1、把你刚才从`智控台`复制过来的`server.secret`的`参数值`复制到`.config.yaml`文件里的`secret`里。
 
-2、把`url`里的`127.0.0.1`改成你电脑局域网内的ip
-
 类似这样的效果
 ```
 manager-api:
-  url: http://192.168.1.25:8002/xiaozhi
+  url: http://xiaozhi-esp32-server-web/xiaozhi
   secret: 12345678-xxxx-xxxx-xxxx-123456789000
 ```
 
@@ -215,14 +199,12 @@ ws://你电脑局域网的ip:8000/xiaozhi/v1/
 5.1、执行以下命令
 
 ```
-docker-compose down
+docker compose down
 docker rmi ghcr.nju.edu.cn/xinnan-tech/xiaozhi-esp32-server:server_latest
 docker rmi ghcr.nju.edu.cn/xinnan-tech/xiaozhi-esp32-server:web_latest
+docker compose pull
+docker compose up -d
 ```
-
-5.2、删掉`docker-compose_all.yaml`文件
-
-5.3、重新按1.1开始部署
 
 # 方式二：本地源码运行全模块
 

--- a/docs/Deployment_all.md
+++ b/docs/Deployment_all.md
@@ -44,6 +44,8 @@ xiaozhi-server
 在页面的右侧找到名称为`RAW`按钮，在`RAW`按钮的旁边，找到下载的图标，点击下载按钮，下载`docker-compose_all.yml`文件。 把文件下载到你的
 `xiaozhi-server`中。
 
+或者直接执行 `wget https://raw.githubusercontent.com/xinnan-tech/xiaozhi-esp32-server/refs/heads/main/main/xiaozhi-server/docker-compose_all.yml` 下载。
+
 下载完后，回到本教程继续往下。
 
 ##### 1.3.2 下载 config_from_api.yaml
@@ -52,6 +54,8 @@ xiaozhi-server
 
 在页面的右侧找到名称为`RAW`按钮，在`RAW`按钮的旁边，找到下载的图标，点击下载按钮，下载`config_from_api.yaml`文件。 把文件下载到你的
 `xiaozhi-server`下面的`data`文件夹中，然后把`config_from_api.yaml`文件重命名为`.config.yaml`。
+
+或者直接执行 `wget https://raw.githubusercontent.com/xinnan-tech/xiaozhi-esp32-server/refs/heads/main/main/xiaozhi-server/config_from_api.yaml` 下载保存。
 
 下载完配置文件后，我们确认一下整个`xiaozhi-server`里面的文件如下所示：
 

--- a/main/xiaozhi-server/docker-compose_all.yml
+++ b/main/xiaozhi-server/docker-compose_all.yml
@@ -1,25 +1,17 @@
 # Docker安装全模块
 
-# 1、安装mysql
-# |- 如果本机已经安装了MySQL，可以直接在数据库中创建名为`xiaozhi_esp32_server`的数据库。
-# |- 如果还没有MySQL，你可以通过docker安装mysql,执行以下一句话
-# |- docker run --name xiaozhi-esp32-server-db -e MYSQL_ROOT_PASSWORD=123456 -p 3306:3306 -e MYSQL_DATABASE=xiaozhi_esp32_server -e MYSQL_INITDB_ARGS="--character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci" -d mysql:latest
-# |- 记得修改下方SPRING_DATASOURCE_DRUID_URL的IP，ip不能写127.0.0.1或localhost，否则容器无法访问，要写你电脑局域网ip
-
-# 2、安装redis
-# |- 如果本机已经安装了Redis，看一下你安装的redis端口、密码，然后修改下方redis的地址和端口
-# |- 如果还没有Redis，你可以通过docker安装redis,执行以下一句话
-# |- docker run --name xiaozhi-esp32-server-redis -d -p 6379:6379 redis
-# |- 记得修改SPRING_DATA_REDIS_HOST的IP，ip不能写127.0.0.1或localhost，否则容器无法访问，要写你电脑局域网ip
-
-
 version: '3'
 services:
   # Server模块
   xiaozhi-esp32-server:
     image: ghcr.nju.edu.cn/xinnan-tech/xiaozhi-esp32-server:server_latest
     container_name: xiaozhi-esp32-server
+    depends_on:
+      - xiaozhi-esp32-server-db
+      - xiaozhi-esp32-server-redis
     restart: always
+    networks:
+      - default
     ports:
       # ws服务端
       - "8000:8000"
@@ -38,14 +30,53 @@ services:
     image: ghcr.nju.edu.cn/xinnan-tech/xiaozhi-esp32-server:web_latest
     container_name: xiaozhi-esp32-server-web
     restart: always
+    networks:
+      - default
+    depends_on:
+      - xiaozhi-esp32-server-db
+      - xiaozhi-esp32-server-redis
     ports:
       # 智控台
       - "8002:8002"
     environment:
       - TZ=Asia/Shanghai
       ##记得改mysql和redis IP 密码
-      - SPRING_DATASOURCE_DRUID_URL=jdbc:mysql://192.168.1.25:3306/xiaozhi_esp32_server?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Shanghai
+      - SPRING_DATASOURCE_DRUID_URL=jdbc:mysql://xiaozhi-esp32-server-db:3306/xiaozhi_esp32_server?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Shanghai
       - SPRING_DATASOURCE_DRUID_USERNAME=root
       - SPRING_DATASOURCE_DRUID_PASSWORD=123456
-      - SPRING_DATA_REDIS_HOST=192.168.1.25
+      - SPRING_DATA_REDIS_HOST=xiaozhi-esp32-server-redis
       - SPRING_DATA_REDIS_PORT=6379
+  xiaozhi-esp32-server-db:
+    image: mysql:latest
+    container_name: xiaozhi-esp32-server-db
+    healthcheck:
+      test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
+      timeout: 45s
+      interval: 10s
+      retries: 10
+    restart: always
+    networks:
+      - default
+    expose:
+      - 3306
+    volumes:
+      - ./mysql/data:/var/lib/mysql
+    environment:
+      - TZ=Asia/Shanghai
+      - MYSQL_ROOT_PASSWORD=123456
+      - MYSQL_DATABASE=xiaozhi_esp32_server
+      - MYSQL_INITDB_ARGS="--character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci"
+  xiaozhi-esp32-server-redis:
+    image: redis
+    expose:
+      - 6379
+    container_name: xiaozhi-esp32-server-redis
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    networks:
+      - default
+networks:
+  default:


### PR DESCRIPTION
1. 支持同步安装 MySQL 与 Redis
2. 支持 MySQL 与 Redis 的健康检查
3. 添加了服务依赖、当 MySQL 与 Redis 准备好之后，再启动 web 与 sever
4. 同步更新了配置文档，简化了安装与更新的步骤。
5. server 与 db 和 Redis 的通信使用 docker 服务名称，避免了手动配置，只需要配置 MySQL 密码。
6. 更新的时候不需要删除 docker-compose_all.yml