### PR TITLE
feat: 支持通过OTA更新websocket地址

### DIFF
--- a/main/manager-api/src/main/java/xiaozhi/modules/device/dto/DeviceReportRespDTO.java
+++ b/main/manager-api/src/main/java/xiaozhi/modules/device/dto/DeviceReportRespDTO.java
@@ -19,6 +19,9 @@ public class DeviceReportRespDTO {
 
     @Schema(description = "固件版本信息")
     private Firmware firmware;
+    
+    @Schema(description = "WebSocket配置")
+    private Websocket websocket;
 
     @Getter
     @Setter
@@ -59,5 +62,12 @@ public class DeviceReportRespDTO {
 
         @Schema(description = "时区偏移量，单位为分钟")
         private Integer timezone_offset;
+    }
+    
+    @Getter
+    @Setter
+    public static class Websocket {
+        @Schema(description = "WebSocket服务器地址")
+        private String url;
     }
 }

--- a/main/manager-api/src/main/java/xiaozhi/modules/device/service/impl/DeviceServiceImpl.java
+++ b/main/manager-api/src/main/java/xiaozhi/modules/device/service/impl/DeviceServiceImpl.java
@@ -47,6 +47,8 @@ public class DeviceServiceImpl extends BaseServiceImpl<DeviceDao, DeviceEntity> 
 
     private final RedisTemplate<String, Object> redisTemplate;
 
+    private final SysParamsService sysParamsService;
+
     // 添加构造函数来初始化 deviceMapper
     public DeviceServiceImpl(DeviceDao deviceDao, SysUserUtilService sysUserUtilService,
             SysParamsService sysParamsService,
@@ -55,6 +57,7 @@ public class DeviceServiceImpl extends BaseServiceImpl<DeviceDao, DeviceEntity> 
         this.sysUserUtilService = sysUserUtilService;
         this.frontedUrl = sysParamsService.getValue(Constant.SERVER_FRONTED_URL, true);
         this.redisTemplate = redisTemplate;
+        this.sysParamsService = sysParamsService;
     }
 
     @Override
@@ -131,6 +134,16 @@ public class DeviceServiceImpl extends BaseServiceImpl<DeviceDao, DeviceEntity> 
         firmware.setVersion(deviceReport.getApplication().getVersion());
         firmware.setUrl("http://localhost:8002/xiaozhi/ota/download");
         response.setFirmware(firmware);
+        
+        // 添加WebSocket配置
+        DeviceReportRespDTO.Websocket websocket = new DeviceReportRespDTO.Websocket();
+        // 从系统参数获取WebSocket URL，如果未配置则使用默认值
+        String wsUrl = sysParamsService.getValue("websocket_url", true);
+        if (StringUtils.isBlank(wsUrl)) {
+            wsUrl = "ws://localhost:8000/xiaozhi/v1/";
+        }
+        websocket.setUrl(wsUrl);
+        response.setWebsocket(websocket);
 
         DeviceEntity deviceById = getDeviceById(macAddress);
         if (deviceById != null) { // 如果设备存在，则更新上次连接时间


### PR DESCRIPTION
xiaozhi-esp32的最新更新已经支持从OTA获取websocket地址，不需要再次编译固件。
见这个提交：https://github.com/78/xiaozhi-esp32/commit/3404180a776b5473531fbb9658add706155e32a8

本PR已经自测通过。

![image](https://github.com/user-attachments/assets/88500f19-2ec5-49a0-ae79-997b0a534593)

使用test_page.html也测试通过：
```
[23:37:52.874] 正在检查OTA状态...
[23:37:52.978] OTA检查结果: {"server_time":{"timestamp":1745249872874,"timeZone":"Asia/Shanghai","timezone_offset":480},"firmware":{"version":"1.0.0","url":"http://localhost:8002/xiaozhi/ota/download"},"websocket":{"url":"wss://{我的私有地址}/xiaozhi/v1/"}}
[23:37:52.979] OTA检查通过，开始连接WebSocket...
[23:37:52.979] 正在连接: wss://{我的私有地址}/xiaozhi/v1/?device-id=00%3A11%3A22%3A33%3A44%3A55&client-id=web_test_client
```
