### PR TITLE
添加前端部署路径环境变量

### DIFF
--- a/main/manager-web/.env.production
+++ b/main/manager-web/.env.production
@@ -1,3 +1,4 @@
 VUE_APP_API_BASE_URL=/xiaozhi
+VUE_APP_PUBLIC_PATH=/
 # 是否开启CDN
 VUE_APP_USE_CDN=false

--- a/main/manager-web/package.json
+++ b/main/manager-web/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "core-js": "^3.41.0",
     "cross-env": "^7.0.3",
+    "dotenv": "^16.5.0",
     "element-ui": "^2.15.14",
     "flyio": "^0.6.14",
     "normalize.css": "^8.0.1",

--- a/main/manager-web/vue.config.js
+++ b/main/manager-web/vue.config.js
@@ -39,7 +39,7 @@ const cdnResources = {
 const useCDN = process.env.VUE_APP_USE_CDN === 'true';
 
 module.exports = defineConfig({
-  productionSourceMap: process.env.NODE_ENV === 'production' ? false : true, // 生产环境不生成 source map
+  productionSourceMap: process.env.NODE_ENV !=='production', // 生产环境不生成 source map
   devServer: {
     port: 8001, // 指定端口为 8001
     proxy: {
@@ -52,6 +52,7 @@ module.exports = defineConfig({
       overlay: false, // 不显示 webpack 错误覆盖层
     },
   },
+  publicPath: process.env.VUE_APP_PUBLIC_PATH || "",
   chainWebpack: config => {
 
     // 修改 HTML 插件配置，动态插入 CDN 链接


### PR DESCRIPTION
- 添加 `VUE_APP_PUBLIC_PATH` 环境变量，允许用户自行指定智控台（前端）的部署路径并编译
- 依赖补充 `"dotenv"`