### PR TITLE
fix：修复tts多次尝试逻辑

### DIFF
--- a/main/xiaozhi-server/core/providers/tts/base.py
+++ b/main/xiaozhi-server/core/providers/tts/base.py
@@ -29,15 +29,19 @@ class TTSProviderBase(ABC):
                 try:
                     asyncio.run(self.text_to_speak(text, tmp_file))
                 except Exception as e:
-                    logger.bind(tag=TAG).error(f"语音生成失败: {text}，错误: {e}")
-                if not os.path.exists(tmp_file):
+                    logger.bind(tag=TAG).warning(f"语音生成失败{5 - max_repeat_time + 1}次: {text}，错误: {e}")
+                    # 未执行成功，删除文件
+                    if os.path.exists(tmp_file):
+                        os.remove(tmp_file)
                     max_repeat_time -= 1
-                    if max_repeat_time > 0:
-                        logger.bind(tag=TAG).error(f"再试{max_repeat_time}次")
 
             if max_repeat_time > 0:
                 logger.bind(tag=TAG).info(
                     f"语音生成成功: {text}:{tmp_file}，重试{5 - max_repeat_time}次"
+                )
+            else:
+                logger.bind(tag=TAG).error(
+                    f"语音生成失败: {text}，请检查网络或服务是否正常"
                 )
 
             return tmp_file


### PR DESCRIPTION
tts未及时响应，多次尝试逻辑修复。（tts失败会生成空文件，需删除空文件，达成While的条件，再次调用tts）