### PR TITLE
采用约定大于配置的原则，减少用户冗余设置，用户仅调整自定义设置

### DIFF
--- a/main/xiaozhi-server/config/settings.py
+++ b/main/xiaozhi-server/config/settings.py
@@ -1,6 +1,10 @@
 import os
 from collections.abc import Mapping
+from config import logger
 from config.config_loader import read_config, get_project_dir, load_config
+
+TAG = __name__
+logger = logger.setup_logging()
 
 default_config_file = "config.yaml"
 
@@ -34,31 +38,16 @@ def find_missing_keys(new_config, old_config, parent_key=""):
 
 
 def check_config_file():
-    old_config_file = get_project_dir() + "data/." + default_config_file
-    if not os.path.exists(old_config_file):
-        return
-    old_config = load_config()
-    new_config = read_config(get_project_dir() + default_config_file)
-    # 查找缺失的配置项
-    missing_keys = find_missing_keys(new_config, old_config)
-    read_config_from_api = old_config.get("read_config_from_api", False)
-    if read_config_from_api:
-        old_config_origin = read_config(old_config_file)
-        if old_config_origin.get("selected_module") is not None:
-            missing_keys_str = "\n".join(f"- {key}" for key in missing_keys)
-            error_msg = "您的配置文件好像既包含智控台的配置又包含本地配置：\n"
-            error_msg += "\n建议您：\n"
-            error_msg += "1、将根目录的config_from_api.yaml文件复制到data下，重命名为.config.yaml\n"
-            error_msg += "2、按教程配置好接口地址和密钥\n"
-            raise ValueError(error_msg)
-        return
-
-    if missing_keys:
-        missing_keys_str = "\n".join(f"- {key}" for key in missing_keys)
-        error_msg = "您的配置文件太旧了，缺少了：\n"
-        error_msg += missing_keys_str
-        error_msg += "\n建议您：\n"
-        error_msg += "1、备份data/.config.yaml文件\n"
-        error_msg += "2、将根目录的config.yaml文件复制到data下，重命名为.config.yaml\n"
-        error_msg += "3、将密钥逐个复制到新的配置文件中\n"
-        raise ValueError(error_msg)
+    """
+    简化的配置检查，仅提示用户配置文件的使用情况
+    """
+    custom_config_file = get_project_dir() + "data/." + default_config_file
+    if not os.path.exists(custom_config_file):
+        logger.bind(tag=TAG).info("提示: 使用默认配置文件。如需自定义配置，请创建 data/.config.yaml 文件")
+    else:
+        logger.bind(tag=TAG).info(f"提示: 使用自定义配置文件 data/.config.yaml，配置将覆盖默认值")
+    
+    # 检查是否从API读取配置
+    config = load_config()
+    if config.get("read_config_from_api", False):
+        logger.bind(tag=TAG).info("提示: 从API获取配置")


### PR DESCRIPTION
定义：

- `config.yaml`为默认配置； 定义当前支持的各种可设置的参数和默认参数；
- `data/.config.yaml` 为自定义配置；用户设置相关参数，未设置部分读取 `config.yaml`默认配置

参考“**约定大于配置**”的思想，使用者通过设置自定义配置即可完成启动，无需关默认配置项，减少用户冗余配置；

例如：仅通过以下 `data/.config.yaml` 配置，即可完成使用AliLLM，无需编写其他无用配置
```yaml
selected_module:
  LLM: AliLLM

Intent:
  intent_llm:
    type: intent_llm
    llm: AliLLM

LLM:
  AliLLM:
    api_key: sk-********************************
```