### PR TITLE
fix: get_server_config 异常修复

### DIFF
--- a/main/xiaozhi-server/config/manage_api_client.py
+++ b/main/xiaozhi-server/config/manage_api_client.py
@@ -145,6 +145,7 @@ def get_agent_models(
             "macAddress": mac_address,
             "clientId": client_id,
             "selectedModule": selected_module,
+            "secret": ManageApiClient._secret,  # 添加必要的secret字段到请求体
         },
     )
 

--- a/main/xiaozhi-server/config/manage_api_client.py
+++ b/main/xiaozhi-server/config/manage_api_client.py
@@ -127,7 +127,10 @@ class ManageApiClient:
 def get_server_config() -> Optional[Dict]:
     """获取服务器基础配置"""
     return ManageApiClient._instance._execute_request(
-        "POST", "/config/server-base"
+        "POST", "/config/server-base",
+        json={
+            "secret": ManageApiClient._secret  # 添加必要的secret字段到请求体
+        }
     )
 
 


### PR DESCRIPTION
最新的main分支中， config_from_api 模式下， 不发送secret 会出错。