### PR TITLE
feat: MCP server支持使用sse模式

### DIFF
--- a/main/xiaozhi-server/core/mcp/manager.py
+++ b/main/xiaozhi-server/core/mcp/manager.py
@@ -50,9 +50,9 @@ class MCPManager:
         """初始化所有MCP服务"""
         config = self.load_config()
         for name, srv_config in config.items():
-            if not srv_config.get("command"):
+            if not srv_config.get("command") and not srv_config.get("url"):
                 self.logger.bind(tag=TAG).warning(
-                    f"Skipping server {name}: command not specified"
+                    f"Skipping server {name}: neither command nor url specified"
                 )
                 continue
 

--- a/main/xiaozhi-server/mcp_server_settings.json
+++ b/main/xiaozhi-server/mcp_server_settings.json
@@ -26,6 +26,9 @@
       "command": "npx",
       "args": ["-y", "@simonb97/server-win-cli"],
       "link": "https://github.com/SimonB97/win-cli-mcp-server"
+    },
+    "perplexity-ask": {
+      "url": "http://your-server-ip:your-port/sse"
     }
   }
 }

--- a/main/xiaozhi-server/mcp_server_settings.json
+++ b/main/xiaozhi-server/mcp_server_settings.json
@@ -3,7 +3,8 @@
     "在data目录下创建.mcp_server_settings.json文件，可以选择下面的MCP服务，也可以自行添加新的MCP服务。",
     "后面不断测试补充好用的mcp服务，欢迎大家一起补充。",
     "记得删除注释行,des属性仅为说明,不会被解析。",
-    "des和link属性，仅为说明安装方式，方便大家查看原始链接，不是必须项。"
+    "des和link属性，仅为说明安装方式，方便大家查看原始链接，不是必须项。",
+    "当前支持stdio/sse两种模式。"
   ],
   "mcpServers": {
     "filesystem": {
@@ -26,9 +27,6 @@
       "command": "npx",
       "args": ["-y", "@simonb97/server-win-cli"],
       "link": "https://github.com/SimonB97/win-cli-mcp-server"
-    },
-    "perplexity-ask": {
-      "url": "http://your-server-ip:your-port/sse"
     }
   }
 }

--- a/main/xiaozhi-server/requirements.txt
+++ b/main/xiaozhi-server/requirements.txt
@@ -22,7 +22,7 @@ mem0ai==0.1.62
 bs4==0.0.2
 modelscope==1.23.2
 sherpa_onnx==1.11.0
-mcp==1.4.1
+mcp==1.7.1
 cnlunar==0.2.0
 PySocks==1.7.1
 dashscope==1.23.1


### PR DESCRIPTION
当前MCP client的实现只支持`stdio`的模式，有些时候本地环境不方便，需要使用`sse`等模式时直接报错。
这里增强了一下这块的能力，已经自测通过可以使用。

同时在示例的`mcp_server_settings.json`中添加了一个描述。

使用示例：
```json
  "example-sse-server": {
      "url": "http://your-server-ip:your-port/sse"
    }
```