### PR TITLE
build(Dockerfile-server): 使用阿里云镜像源加速国内构建- 在 Python 依赖安装中添加阿里云 PyPI 镜像源

### DIFF
--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -6,12 +6,15 @@ WORKDIR /app
 COPY main/xiaozhi-server/requirements.txt .
 
 # 安装Python依赖
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt -i https://mirrors.aliyun.com/pypi/simple
 
 # 第二阶段：生产镜像
 FROM python:3.10-slim
 
 WORKDIR /opt/xiaozhi-esp32-server
+
+# if you located in China, you can use aliyun mirror to speed up
+RUN sed -i 's@deb.debian.org@mirrors.aliyun.com@g' /etc/apt/sources.list.d/debian.sources
 
 # 安装系统依赖
 RUN apt-get update && \


### PR DESCRIPTION
- 在系统依赖安装前修改 APT 镜像源为阿里云