### PR TITLE
build(Dockerfile-server): 使用清华大学镜像源加速国内构建

### DIFF
--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -6,12 +6,15 @@ WORKDIR /app
 COPY main/xiaozhi-server/requirements.txt .
 
 # 安装Python依赖
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple
 
 # 第二阶段：生产镜像
 FROM python:3.10-slim
 
 WORKDIR /opt/xiaozhi-esp32-server
+
+# if you located in China, you can use tsinghua mirror to speed up
+RUN sed -i 's@deb.debian.org@mirrors.tuna.tsinghua.edu.cn@g' /etc/apt/sources.list.d/debian.sources
 
 # 安装系统依赖
 RUN apt-get update && \


### PR DESCRIPTION
- 在 Python 依赖安装中使用清华大学 PyPI 镜像源
- 在系统依赖安装前切换到清华大学 APT 镜像源