### PR TITLE
feature: 新增结束词prompt自定义能力。

### DIFF
--- a/main/xiaozhi-server/config.yaml
+++ b/main/xiaozhi-server/config.yaml
@@ -143,6 +143,13 @@ prompt: |
   - 长篇大论，叽叽歪歪
   - 长时间严肃对话
 
+# 结束语prompt
+end_prompt:
+  enable: true # 是否开启结束语
+  # 结束语
+  prompt: |
+    请你以“时间过得真快”未来头，用富有感情、依依不舍的话来结束这场对话吧。！
+
 # 具体处理时选择的模块(The module selected for specific processing)
 selected_module:
   # 语音活动检测模块，默认使用SileroVAD模型

--- a/main/xiaozhi-server/core/handle/receiveAudioHandle.py
+++ b/main/xiaozhi-server/core/handle/receiveAudioHandle.py
@@ -98,9 +98,16 @@ async def no_voice_close_connect(conn):
             conn.close_after_chat = True
             conn.client_abort = False
             conn.asr_server_receive = False
-            prompt = (
-                "请你以“时间过得真快”未来头，用富有感情、依依不舍的话来结束这场对话吧。"
-            )
+            end_prompt = conn.config.get("end_prompt", {})
+            if end_prompt and end_prompt.get("enable", False) is False:
+                conn.logger.bind(tag=TAG).info("结束对话，无需发送结束提示语")
+                conn.asr_server_receive = True
+                await conn.close()
+                return
+            prompt = end_prompt.get("prompt")
+            if not prompt:
+                conn.logger.bind(tag=TAG).warn("开启结束对话提示词功能，但未配置结束提示语！请确认配置文件end_prompt字段下是否包含prompt属性！")
+                prompt = '请你以“时间过得真快”未来头，用富有感情、依依不舍的话来结束这场对话吧。！'
             await startToChat(conn, prompt)
 
 

--- a/main/xiaozhi-server/core/handle/receiveAudioHandle.py
+++ b/main/xiaozhi-server/core/handle/receiveAudioHandle.py
@@ -99,9 +99,8 @@ async def no_voice_close_connect(conn):
             conn.client_abort = False
             conn.asr_server_receive = False
             end_prompt = conn.config.get("end_prompt", {})
-            if end_prompt and end_prompt.get("enable", False) is False:
+            if end_prompt and end_prompt.get("enable", True) is False:
                 conn.logger.bind(tag=TAG).info("结束对话，无需发送结束提示语")
-                conn.asr_server_receive = True
                 await conn.close()
                 return
             prompt = end_prompt.get("prompt")


### PR DESCRIPTION
新增：
新增在python服务端在config配置内自定义结束词提示词（end_prompt），仅在enable为True时触发结束聊天，否则自动默认清理资源退出。

----
配置enable属性是为了让用户更灵活控制结束词，即使暂时不想使用结束词也不需要删除该配置。

close(#963)