### PR TITLE
fix：修复“小智服务器测试页面播放语音问题”

### DIFF
--- a/main/xiaozhi-server/test/test_page.html
+++ b/main/xiaozhi-server/test/test_page.html
@@ -879,6 +879,7 @@
                                         // 流已结束且没有更多数据
                                         log("音频播放完成", 'info');
                                         isAudioPlaying = false;
+                                        this.endOfStream = false;
                                         streamingContext = null;
                                     } else {
                                         // 等待更多数据
@@ -1409,6 +1410,17 @@
                 };
 
                 websocket.onclose = () => {
+
+                    // 清理音频缓冲和播放状态
+                    audioBufferQueue = [];
+                    isAudioBuffering = false;
+                    isAudioPlaying = false;
+                    streamingContext = null;
+                    if (visualizationRequest) {
+                        cancelAnimationFrame(visualizationRequest);
+                        visualizationRequest = null;
+                    }
+
                     log('已断开连接', 'info');
                     connectionStatus.textContent = 'ws已断开';
                     connectionStatus.style.color = 'red';
@@ -1562,6 +1574,10 @@
         function sendTextMessage() {
             const message = messageInput.value.trim();
             if (message === '' || !websocket || websocket.readyState !== WebSocket.OPEN) return;
+
+            audioBufferQueue = [];
+            isAudioBuffering = false;
+            isAudioPlaying = false;
 
             try {
                 // 直接发送listen消息，不需要重复发送hello
@@ -2382,6 +2398,8 @@
                     // 如果收到的是第一个音频包，开始缓冲过程
                     if (audioBufferQueue.length === 1 && !isAudioBuffering && !isAudioPlaying) {
                         startAudioBuffering();
+                    } else if (isAudioPlaying && streamingContext) {
+                        streamingContext.decodeOpusFrames([opusData]);
                     }
                 } else {
                     log('收到空音频数据帧，可能是结束标志', 'warning');


### PR DESCRIPTION
1、修复“第一段话有语音输出，后续的回答都是静音”问题
2、发送消息时重置音频状态，避免“连续对话时，前一次交互的音频数据残留在 audioBufferQueue 中，导致新旧数据混合，播放逻辑混乱。”问题
3、添加“断开连接后，所有音频相关的状态都被重置”