### PR TITLE
SSEClient支持认证

### DIFF
--- a/main/xiaozhi-server/core/mcp/MCPClient.py
+++ b/main/xiaozhi-server/core/mcp/MCPClient.py
@@ -96,7 +96,11 @@ class MCPClient:
                     read_stream, write_stream = stdio_r, stdio_w
                 # 建立SSEClient
                 elif "url" in self.config:
-                    sse_r, sse_w = await stack.enter_async_context(sse_client(self.config["url"]))
+                    if "API_ACCESS_TOKEN" in self.config:
+                        headers = {"Authorization": f"Bearer {self.config['API_ACCESS_TOKEN']}"}
+                    else:
+                        headers = {}
+                    sse_r, sse_w = await stack.enter_async_context(sse_client(self.config["url"], , headers=headers))
                     read_stream, write_stream = sse_r, sse_w
 
                 else:


### PR DESCRIPTION
当前SSEClient不支持access_key参数和认证，无法通过SSE直接连接homeassistant的mcp_server。添加了认证的header，经过测试可以正常连接homeassistant。
测试的mcp配置文件：
"mcpServers": {
    "Home Assistant": {
      "url": "http://192.168.31.22:8123/mcp_server/sse",
      "API_ACCESS_TOKEN":    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIxZTFiYjYwNGM4ZDY0YmRlODU3NWFmZmFhNDVlZDEzMSIsImlhdCI6MTc0ODE3NDI3NiwiZXhwIjoyMDYzNTM0Mjc2fQ.E5QjiAQE_utNexB1D2_Hbd7mptviP7GPjfGkeA3Zdq8"
    }
  }