### PR TITLE
feat: 支持腾讯云开发AI Agent API调用

### DIFF
--- a/main/xiaozhi-server/config.yaml
+++ b/main/xiaozhi-server/config.yaml
@@ -388,6 +388,17 @@ LLM:
     model_name: "gemini-2.0-flash"
     http_proxy: ""  #"http://127.0.0.1:10808"
     https_proxy: "" #http://127.0.0.1:10808"
+  TCBAiLLM:
+    # 腾讯云开发 - AI+ Agent 平台
+    # 定义 Agent API 类型
+    type: openai
+    # 1. 先创建开通云开发环境 https://tcb.cloud.tencent.com/dev
+    # 2. 进入环境->环境配置-> API Key配置，创建API Key （即 api_key 字段值）
+    # 3. 进入Ai+ 页面 -> 新建Agent，新建后获取 Agent ID （即 model_name 字段值）
+    # 4. Agent 详情页 -> 接入指引 -> 接口调用 -> OpenAI 协议调用示例，获取 base_url 字段（例：https://${您的环境ID}.api.tcloudbasegateway.com/v1/aibot/openai）
+    base_url: "" # https://${您的环境ID}.api.tcloudbasegateway.com/v1/aibot/openai
+    model_name: "你的腾讯云开发AI Agent的Agent ID"
+    api_key: 你的腾讯云开发环境的 API Key
   CozeLLM:
     # 定义LLM API类型
     type: coze


### PR DESCRIPTION
[腾讯云开发平台](https://tcb.cloud.tencent.com/dev)提供一系列与 AI 相关的功能，如大模型接入、 Agent 开发等，助力开发者为自己的小程序、web 或者应用快速接入 AI 能力 ([文档站指引](https://docs.cloudbase.net/ai/introduce))

为帮助小智项目开发者集成云开发AI 调用能力，config.yaml 中添加了Agent API 调用配置

测试验证如下：
1. 进入云开发平台创建“房产创作大师Agent”
<img width="1470" alt="Clipboard_Screenshot_1748870172" src="https://github.com/user-attachments/assets/d2279f27-f59a-447f-b70a-e03955410357" />
2. 本地启动运行xiaozhi-esp32-server，通过 test_page 测试验证结果如下
<img width="1137" alt="Clipboard_Screenshot_1748870334" src="https://github.com/user-attachments/assets/8e2e4233-cea3-4e29-a960-397d90934276" />

