### PR TITLE
fix: 使用deepseek r1-0528模型时，tools_call为空list，tools_call[0]报错

### DIFF
--- a/main/xiaozhi-server/core/connection.py
+++ b/main/xiaozhi-server/core/connection.py
@@ -651,7 +651,7 @@ class ConnectionHandler:
                     # print("content_arguments", content_arguments)
                     tool_call_flag = True
 
-                if tools_call:
+                if tools_call is not None and len(tools_call) > 0:
                     tool_call_flag = True
                     if tools_call[0].id is not None:
                         function_id = tools_call[0].id

--- a/main/xiaozhi-server/core/connection.py
+++ b/main/xiaozhi-server/core/connection.py
@@ -651,7 +651,7 @@ class ConnectionHandler:
                     # print("content_arguments", content_arguments)
                     tool_call_flag = True
 
-                if tools_call is not None:
+                if tools_call:
                     tool_call_flag = True
                     if tools_call[0].id is not None:
                         function_id = tools_call[0].id


### PR DESCRIPTION
原代码
```
if tools_call is not None:
  tool_call_flag = True
  if tools_call[0].id is not None:             # tools_call[0] 会触发 IndexError
```
![image](https://github.com/user-attachments/assets/0ce24f72-fb55-41c2-aca3-00046d9869b8)
