### PR TITLE
feat: 支持配置化请求伪装以兼容不支持 PUT/DELETE 的服务

### DIFF
--- a/main/manager-web/.env.production
+++ b/main/manager-web/.env.production
@@ -2,3 +2,13 @@ VUE_APP_API_BASE_URL=/xiaozhi
 VUE_APP_PUBLIC_PATH=/
 # 是否开启CDN
 VUE_APP_USE_CDN=false
+# 是否启用请求方法覆盖。默认关闭。
+# 某些服务器默认不支持 PUT、DELETE 方法，开启此配置后，
+# 所有 PUT / DELETE 请求会被包装为 POST，并通过 X-HTTP-Method-Override 头传递原始方法。
+# 开启后，需在 nginx 的 location 区块中添加以下配置：
+# set $method $request_method;
+# if ($http_X_HTTP_Method_Override ~* 'PUT|DELETE') {
+#     set $method $http_X_HTTP_Method_Override;
+# }
+# proxy_method $method;
+VUE_APP_HTTP_METHOD_OVERRIDE=false

--- a/main/manager-web/src/apis/httpRequest.js
+++ b/main/manager-web/src/apis/httpRequest.js
@@ -30,10 +30,17 @@ function sendRequest() {
             if (isNotNull(store.getters.getToken)) {
                 this._header.Authorization = 'Bearer ' + (JSON.parse(store.getters.getToken)).token
             }
-
+            // 判断是否启用请求方法覆盖
+            const shouldOverride = process.env.NODE_ENV === 'production'
+                && process.env.VUE_APP_HTTP_METHOD_OVERRIDE === 'true'
+                && ['PUT', 'DELETE'].includes(this._method)
+            const realMethod = shouldOverride ? 'POST' : this._method
+            if (shouldOverride) {
+                this._header['X-HTTP-Method-Override'] = this._method
+            }
             // 打印请求信息
             fly.request(this._url, this._data, {
-                method: this._method,
+                method: realMethod,
                 headers: this._header,
                 responseType: this._responseType
             }).then((res) => {


### PR DESCRIPTION
- 在生产环境中，针对 PUT/DELETE 请求，通过设置 X-HTTP-Method-Override 头实现请求方法覆盖
- 增加全局配置项 VUE_APP_HTTP_METHOD_OVERRIDE 控制是否启用该功能，默认关闭
- Nginx location 区块中增加对应配置以支持后端识别伪装请求方法