### PR TITLE
🐞 fix: 只清空当前数据库，不清空整个数据库

### DIFF
--- a/main/manager-api/src/main/resources/lua/emptyAll.lua
+++ b/main/manager-api/src/main/resources/lua/emptyAll.lua
@@ -1,1 +1,1 @@
-redis.call('FLUSHALL')
+redis.call('FLUSHDB')


### PR DESCRIPTION
-- emptyAll.lua
1、当redis被多个项目使用时，清空了其它项目的库（影响其它项目）