### PR TITLE
客户端连接成功时不主动发送hello

### DIFF
--- a/main/xiaozhi-server/core/connection.py
+++ b/main/xiaozhi-server/core/connection.py
@@ -193,7 +193,6 @@ class ConnectionHandler:
 
             self.welcome_msg = self.config["xiaozhi"]
             self.welcome_msg["session_id"] = self.session_id
-            self.logger.bind(tag=TAG).info(f"客户端 {self.device_id} 连接成功")
 
             # 获取差异化配置
             self._initialize_private_config()

--- a/main/xiaozhi-server/core/connection.py
+++ b/main/xiaozhi-server/core/connection.py
@@ -193,7 +193,7 @@ class ConnectionHandler:
 
             self.welcome_msg = self.config["xiaozhi"]
             self.welcome_msg["session_id"] = self.session_id
-            await self.websocket.send(json.dumps(self.welcome_msg))
+            self.logger.bind(tag=TAG).info(f"客户端 {self.device_id} 连接成功")
 
             # 获取差异化配置
             self._initialize_private_config()


### PR DESCRIPTION
根据xiaozhi websocket协议，hello消息由客户端发送，服务器端回复。当前实现中当客户端连接成功时会立即发送hello，不符合协议设计。