### PR TITLE
fix: 修正VLLM本地调用，question参数为空会用英文回复的问题

### DIFF
--- a/main/xiaozhi-server/core/providers/vllm/openai.py
+++ b/main/xiaozhi-server/core/providers/vllm/openai.py
@@ -40,6 +40,7 @@ class VLLMProvider(VLLMProviderBase):
         self.client = openai.OpenAI(api_key=self.api_key, base_url=self.base_url)
 
     def response(self, question, base64_image):
+        question = question + "(请使用中文回复)"
         try:
             messages = [
                 {


### PR DESCRIPTION
question 为空调用智谱AI会报错
以及调用本地的qwen-vl 会使用英文回复
![image](https://github.com/user-attachments/assets/837e7509-3d9c-426b-9522-0416d30f77c4)
![image](https://github.com/user-attachments/assets/30691fb0-610b-44f3-9c91-2dd844a55292)
