### PR TITLE
fix: 修复mcp-proxy命令不存在

### DIFF
--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -21,6 +21,7 @@ RUN apt-get update && \
 
 # 从构建阶段复制Python包和前端构建产物
 COPY --from=builder /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
+COPY --from=builder /usr/local/bin/mcp-proxy /usr/local/bin/mcp-proxy
 
 # 复制应用代码
 COPY main/xiaozhi-server .


### PR DESCRIPTION
pip install mcp-proxy会安装到/usr/local/bin/mcp-proxy，从编译镜像移动到生产镜像内