### PR TITLE
修复mcp工具太多会获取不到内容的bug

### DIFF
--- a/main/manager-api/src/main/java/xiaozhi/modules/agent/service/impl/AgentMcpAccessPointServiceImpl.java
+++ b/main/manager-api/src/main/java/xiaozhi/modules/agent/service/impl/AgentMcpAccessPointServiceImpl.java
@@ -65,6 +65,7 @@ public class AgentMcpAccessPointServiceImpl implements AgentMcpAccessPointServic
             try (WebSocketClientManager client = WebSocketClientManager.build(
                     new WebSocketClientManager.Builder()
                             .uri(wsUrl)
+                            .bufferSize(1024 * 1024)
                             .connectTimeout(8, TimeUnit.SECONDS)
                             .maxSessionDuration(10, TimeUnit.SECONDS))) {
 

--- a/main/manager-api/src/main/java/xiaozhi/modules/sys/utils/WebSocketClientManager.java
+++ b/main/manager-api/src/main/java/xiaozhi/modules/sys/utils/WebSocketClientManager.java
@@ -86,9 +86,13 @@ public class WebSocketClientManager implements Closeable {
         if (sess == null || !sess.isOpen()) {
             throw new IOException("握手失败或会话未打开");
         }
+        // 设置缓冲区
+        sess.setTextMessageSizeLimit(b.bufferSize);
+        sess.setBinaryMessageSizeLimit(b.bufferSize);
         ws.session = sess;
         return ws;
     }
+
 
     /**
      * 发送 Text
@@ -308,10 +312,11 @@ public class WebSocketClientManager implements Closeable {
             if (stopWatch.isRunning()) {
                 stopWatch.stop();
             }
-            log.info("ws连接关闭, 目标URI: {}, 关闭时间: {}, 连接总时长: {}s",
+            log.info("ws连接关闭, 目标URI: {}, 关闭时间: {}, 连接总时长: {}s,断开原因：{}",
                     targetUri, DateUtils.getDateTimeNow(DateUtils.DATE_TIME_MILLIS_PATTERN),
-                    DateUtils.millsToSecond(stopWatch.getTotalTimeMillis()));
+                    DateUtils.millsToSecond(stopWatch.getTotalTimeMillis()),status);
         }
+
     }
 
     public static class Builder {
@@ -321,6 +326,7 @@ public class WebSocketClientManager implements Closeable {
         private long maxSessionDuration = 5; // 最大连线时间，默认5秒
         private TimeUnit maxSessionDurationUnit = TimeUnit.SECONDS; // 最大连线时间单位
         private int queueCapacity = 100; // 消息队列容量
+        private int bufferSize = 8 * 1024; //默认 8kb
         private WebSocketHttpHeaders headers; // 请求头
 
         /**
@@ -350,6 +356,10 @@ public class WebSocketClientManager implements Closeable {
 
         public Builder queueCapacity(int c) {
             this.queueCapacity = c;
+            return this;
+        }
+        public Builder bufferSize(int c) {
+            this.bufferSize = c;
             return this;
         }
 


### PR DESCRIPTION
--WebSocketClientManager.java
1.构建websocket对象的时候，添加可以设置缓冲区大小
2.断开连接的日志添加断开原因的内容
--AgentMcpAccessPointServiceImpl.java
1.设置每个websocket的缓冲区为1m，bug原因：缓存区太小，数据量太大，导致直接断开连接