### PR TITLE
优化

### DIFF
--- a/main/manager-api/src/main/java/xiaozhi/modules/agent/service/impl/AgentServiceImpl.java
+++ b/main/manager-api/src/main/java/xiaozhi/modules/agent/service/impl/AgentServiceImpl.java
@@ -327,7 +327,7 @@ public class AgentServiceImpl extends BaseServiceImpl<AgentDao, AgentEntity> imp
         }
 
         boolean b = validateLLMIntentParams(dto.getLlmModelId(), dto.getIntentModelId());
-        if(!b){
+        if (!b) {
             throw new RenException("LLM大模型和Intent意图识别，选择参数不匹配");
         }
         this.updateById(existingEntity);
@@ -335,19 +335,20 @@ public class AgentServiceImpl extends BaseServiceImpl<AgentDao, AgentEntity> imp
 
     /**
      * 验证大语言模型和意图识别的参数是否符合匹配
-     * @param llmModelId 大语言模型id
+     * 
+     * @param llmModelId    大语言模型id
      * @param intentModelId 意图识别id
      * @return T 匹配 : F 不匹配
      */
-    private boolean validateLLMIntentParams(String llmModelId,String intentModelId){
+    private boolean validateLLMIntentParams(String llmModelId, String intentModelId) {
         ModelConfigEntity llmModelData = modelConfigService.selectById(llmModelId);
         String type = llmModelData.getConfigJson().get("type").toString();
         // 如果查询大语言模型是openai或者ollama，意图识别选参数都可以
-        if("openai".equals(type) || "ollama".equals(type)){
+        if ("openai".equals(type) || "ollama".equals(type)) {
             return true;
         }
-        // 除了openai和ollama的类型，不可以选择id为Intent_nointent（无意图识别）的意图识别
-        return !"Intent_nointent".equals(intentModelId);
+        // 除了openai和ollama的类型，不可以选择id为Intent_function_call（函数调用）的意图识别
+        return !"Intent_function_call".equals(intentModelId);
     }
 
     @Override

--- a/main/manager-api/src/main/java/xiaozhi/modules/agent/service/impl/AgentServiceImpl.java
+++ b/main/manager-api/src/main/java/xiaozhi/modules/agent/service/impl/AgentServiceImpl.java
@@ -41,6 +41,7 @@ import xiaozhi.modules.agent.service.AgentTemplateService;
 import xiaozhi.modules.agent.vo.AgentInfoVO;
 import xiaozhi.modules.device.service.DeviceService;
 import xiaozhi.modules.model.dto.ModelProviderDTO;
+import xiaozhi.modules.model.entity.ModelConfigEntity;
 import xiaozhi.modules.model.service.ModelConfigService;
 import xiaozhi.modules.model.service.ModelProviderService;
 import xiaozhi.modules.security.user.SecurityUser;
@@ -324,7 +325,29 @@ public class AgentServiceImpl extends BaseServiceImpl<AgentDao, AgentEntity> imp
             // 删除音频数据
             agentChatHistoryService.deleteByAgentId(existingEntity.getId(), true, false);
         }
+
+        boolean b = validateLLMIntentParams(dto.getLlmModelId(), dto.getIntentModelId());
+        if(!b){
+            throw new RenException("LLM大模型和Intent意图识别，选择参数不匹配");
+        }
         this.updateById(existingEntity);
+    }
+
+    /**
+     * 验证大语言模型和意图识别的参数是否符合匹配
+     * @param llmModelId 大语言模型id
+     * @param intentModelId 意图识别id
+     * @return T 匹配 : F 不匹配
+     */
+    private boolean validateLLMIntentParams(String llmModelId,String intentModelId){
+        ModelConfigEntity llmModelData = modelConfigService.selectById(llmModelId);
+        String type = llmModelData.getConfigJson().get("type").toString();
+        // 如果查询大语言模型是openai或者ollama，意图识别选参数都可以
+        if("openai".equals(type) || "ollama".equals(type)){
+            return true;
+        }
+        // 除了openai和ollama的类型，不可以选择id为Intent_nointent（无意图识别）的意图识别
+        return !"Intent_nointent".equals(intentModelId);
     }
 
     @Override

--- a/main/manager-api/src/main/java/xiaozhi/modules/model/controller/ModelController.java
+++ b/main/manager-api/src/main/java/xiaozhi/modules/model/controller/ModelController.java
@@ -21,11 +21,7 @@ import xiaozhi.common.utils.ConvertUtils;
 import xiaozhi.common.utils.Result;
 import xiaozhi.modules.agent.service.AgentTemplateService;
 import xiaozhi.modules.config.service.ConfigService;
-import xiaozhi.modules.model.dto.ModelBasicInfoDTO;
-import xiaozhi.modules.model.dto.ModelConfigBodyDTO;
-import xiaozhi.modules.model.dto.ModelConfigDTO;
-import xiaozhi.modules.model.dto.ModelProviderDTO;
-import xiaozhi.modules.model.dto.VoiceDTO;
+import xiaozhi.modules.model.dto.*;
 import xiaozhi.modules.model.entity.ModelConfigEntity;
 import xiaozhi.modules.model.service.ModelConfigService;
 import xiaozhi.modules.model.service.ModelProviderService;
@@ -50,6 +46,14 @@ public class ModelController {
             @RequestParam(required = false) String modelName) {
         List<ModelBasicInfoDTO> modelList = modelConfigService.getModelCodeList(modelType, modelName);
         return new Result<List<ModelBasicInfoDTO>>().ok(modelList);
+    }
+
+    @GetMapping("/llm/names")
+    @Operation(summary = "获取LLM模型信息")
+    @RequiresPermissions("sys:role:normal")
+    public Result<List<LlmModelBasicInfoDTO>> getLlmModelCodeList(@RequestParam(required = false) String modelName) {
+        List<LlmModelBasicInfoDTO> llmModelCodeList = modelConfigService.getLlmModelCodeList(modelName);
+        return new Result<List<LlmModelBasicInfoDTO>>().ok(llmModelCodeList);
     }
 
     @GetMapping("/{modelType}/provideTypes")

--- a/main/manager-api/src/main/java/xiaozhi/modules/model/dto/LlmModelBasicInfoDTO.java
+++ b/main/manager-api/src/main/java/xiaozhi/modules/model/dto/LlmModelBasicInfoDTO.java
@@ -1,0 +1,13 @@
+package xiaozhi.modules.model.dto;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * LLM的模型的基础展示数据
+ */
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class LlmModelBasicInfoDTO extends ModelBasicInfoDTO{
+    private String type;
+}

--- a/main/manager-api/src/main/java/xiaozhi/modules/model/service/ModelConfigService.java
+++ b/main/manager-api/src/main/java/xiaozhi/modules/model/service/ModelConfigService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import xiaozhi.common.page.PageData;
 import xiaozhi.common.service.BaseService;
+import xiaozhi.modules.model.dto.LlmModelBasicInfoDTO;
 import xiaozhi.modules.model.dto.ModelBasicInfoDTO;
 import xiaozhi.modules.model.dto.ModelConfigBodyDTO;
 import xiaozhi.modules.model.dto.ModelConfigDTO;
@@ -12,6 +13,8 @@ import xiaozhi.modules.model.entity.ModelConfigEntity;
 public interface ModelConfigService extends BaseService<ModelConfigEntity> {
 
     List<ModelBasicInfoDTO> getModelCodeList(String modelType, String modelName);
+
+    List<LlmModelBasicInfoDTO> getLlmModelCodeList(String modelName);
 
     PageData<ModelConfigDTO> getPageList(String modelType, String modelName, String page, String limit);
 

--- a/main/manager-api/src/main/java/xiaozhi/modules/model/service/impl/ModelConfigServiceImpl.java
+++ b/main/manager-api/src/main/java/xiaozhi/modules/model/service/impl/ModelConfigServiceImpl.java
@@ -23,10 +23,7 @@ import xiaozhi.common.utils.ConvertUtils;
 import xiaozhi.modules.agent.dao.AgentDao;
 import xiaozhi.modules.agent.entity.AgentEntity;
 import xiaozhi.modules.model.dao.ModelConfigDao;
-import xiaozhi.modules.model.dto.ModelBasicInfoDTO;
-import xiaozhi.modules.model.dto.ModelConfigBodyDTO;
-import xiaozhi.modules.model.dto.ModelConfigDTO;
-import xiaozhi.modules.model.dto.ModelProviderDTO;
+import xiaozhi.modules.model.dto.*;
 import xiaozhi.modules.model.entity.ModelConfigEntity;
 import xiaozhi.modules.model.service.ModelConfigService;
 import xiaozhi.modules.model.service.ModelProviderService;
@@ -51,6 +48,25 @@ public class ModelConfigServiceImpl extends BaseServiceImpl<ModelConfigDao, Mode
                         .select("id", "model_name"));
         return ConvertUtils.sourceToTarget(entities, ModelBasicInfoDTO.class);
     }
+    @Override
+    public List<LlmModelBasicInfoDTO> getLlmModelCodeList(String modelName) {
+        List<ModelConfigEntity> entities = modelConfigDao.selectList(
+                new QueryWrapper<ModelConfigEntity>()
+                        .eq("model_type", "llm")
+                        .eq("is_enabled", 1)
+                        .like(StringUtils.isNotBlank(modelName), "model_name", "%" + modelName + "%")
+                        .select("id", "model_name","config_json"));
+        // 处理获取到的内容
+        return entities.stream().map(item -> {
+            LlmModelBasicInfoDTO dto = new LlmModelBasicInfoDTO();
+            dto.setId(item.getId());
+            dto.setModelName(item.getModelName());
+            String type = item.getConfigJson().get("type").toString();
+            dto.setType(type);
+            return dto;
+        }).toList();
+    }
+
 
     @Override
     public PageData<ModelConfigDTO> getPageList(String modelType, String modelName, String page, String limit) {

--- a/main/manager-api/src/main/java/xiaozhi/modules/model/service/impl/ModelConfigServiceImpl.java
+++ b/main/manager-api/src/main/java/xiaozhi/modules/model/service/impl/ModelConfigServiceImpl.java
@@ -167,6 +167,8 @@ public class ModelConfigServiceImpl extends BaseServiceImpl<ModelConfigDao, Mode
                         .or()
                         .eq("mem_model_id", modelId)
                         .or()
+                        .eq("vllm_model_id", modelId)
+                        .or()
                         .eq("intent_model_id", modelId));
         if (!agents.isEmpty()) {
             String agentNames = agents.stream()

--- a/main/manager-web/src/apis/module/model.js
+++ b/main/manager-web/src/apis/module/model.js
@@ -106,6 +106,22 @@ export default {
         });
       }).send();
   },
+  // 获取LLM模型名称列表
+  getLlmModelCodeList(modelName, callback) {
+    RequestService.sendRequest()
+      .url(`${getServiceUrl()}/models/llm/names`)
+      .method('GET')
+      .data({ modelName })
+      .success((res) => {
+        RequestService.clearRequestTime();
+        callback(res);
+      })
+      .networkFail(() => {
+        RequestService.reAjaxFun(() => {
+          this.getLlmModelCodeList(modelName, callback);
+        });
+      }).send();
+  },
   // 获取模型音色列表
   getModelVoices(modelId, voiceName, callback) {
     const queryParams = new URLSearchParams({


### PR DESCRIPTION
1、智能体配置,当选择的LLM不是openai、ollama类型时,意图模型只能选择“LLM意图识别”。前端下拉、后端保存时也要做校验
2、模型配置,修改模型,修改意图识别里的模型,如果LLM模型不为空,要校验一下它的id是否时在LLM模型里,并且这个模型的供
应器类型只能是openai和ollama类型
3、模型配置,修改视觉模型时,要和其他模块一样,需要看看智能体是否引用了。如果引用了,就不能删除
