### PR TITLE
fix: 修复qwen模型返回toolcall的arguments为None时导致后续请求400

### DIFF
--- a/main/xiaozhi-server/core/connection.py
+++ b/main/xiaozhi-server/core/connection.py
@@ -859,7 +859,7 @@ class ConnectionHandler:
                             {
                                 "id": function_id,
                                 "function": {
-                                    "arguments": '{}' if function_arguments == '' else function_arguments,
+                                    "arguments": "{}" if function_arguments == "" else function_arguments,
                                     "name": function_name,
                                 },
                                 "type": "function",

--- a/main/xiaozhi-server/core/connection.py
+++ b/main/xiaozhi-server/core/connection.py
@@ -859,7 +859,7 @@ class ConnectionHandler:
                             {
                                 "id": function_id,
                                 "function": {
-                                    "arguments": function_arguments,
+                                    "arguments": '{}' if function_arguments == '' else function_arguments,
                                     "name": function_name,
                                 },
                                 "type": "function",


### PR DESCRIPTION
> 使用的大模型为 Qwen3-235B-A22B-Instruct-2507-AWQ
### qwen大模型返回的tool_calls arguments为空，加到dialogue之后导致后续请求报400
<img width="1772" height="235" alt="image" src="https://github.com/user-attachments/assets/3e1a89d9-c8c2-4c14-8656-ad7b7f0cc038" />

<img width="955" height="766" alt="image" src="https://github.com/user-attachments/assets/4246fb5d-07dc-43ce-8948-547f3e64f473" />
