### PR TITLE
修复api接口文档页面,接口文档和点击按钮的说明不一致,串标题的bug

### DIFF
--- a/main/manager-api/pom.xml
+++ b/main/manager-api/pom.xml
@@ -24,6 +24,8 @@
         <hutool.version>5.8.24</hutool.version>
         <jsoup.version>1.19.1</jsoup.version>
         <knife4j.version>4.6.0</knife4j.version>
+        <springdoc.version>2.8.8</springdoc.version>
+        <commons-lang3.version>3.18.0</commons-lang3.version>
         <shiro.version>2.0.2</shiro.version>
         <captcha.version>1.6.2</captcha.version>
         <guava.version>33.0.0-jre</guava.version>
@@ -74,6 +76,7 @@
             <artifactId>easy-captcha</artifactId>
             <version>${captcha.version}</version>
         </dependency>
+
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -190,10 +193,23 @@
             <artifactId>jsoup</artifactId>
             <version>${jsoup.version}</version>
         </dependency>
+        <!--knife4j -->
         <dependency>
             <groupId>com.github.xingfudeshi</groupId>
             <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
             <version>${knife4j.version}</version>
+        </dependency>
+        <!-- springdoc -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>${springdoc.version}</version>
+        </dependency>
+        <!-- 日常工具包 -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
--pom.xml
1.升级了springdoc 2.8.8, knife4j4.6 与 doc2.7.7版本存在兼容问题,按照官方建议升级到2.8.8 解决了此bug 2.升级了 commons-lang3 3.18.0,springdoc 2.8.8 依赖commons-lang低版本存在CVE-2025-48924漏洞,升级版本解决