### PR TITLE
会话上下文解耦重构，创建上下文类，代替conn

### DIFF
--- a/main/xiaozhi-server/core/handle/textHandle.py
+++ b/main/xiaozhi-server/core/handle/textHandle.py
@@ -1,5 +1,6 @@
 from core.handle.textMessageHandlerRegistry import TextMessageHandlerRegistry
 from core.handle.textMessageProcessor import TextMessageProcessor
+from core.session.session_context import SessionContext
 
 TAG = __name__
 
@@ -9,6 +10,6 @@ message_registry = TextMessageHandlerRegistry()
 # 创建全局消息处理器实例
 message_processor = TextMessageProcessor(message_registry)
 
-async def handleTextMessage(conn, message):
+async def handleTextMessage(conn, message, session_context: SessionContext):
     """处理文本消息"""
-    await message_processor.process_message(conn, message)
+    await message_processor.process_message(conn, message, session_context)

--- a/main/xiaozhi-server/core/handle/textHandler/abortMessageHandler.py
+++ b/main/xiaozhi-server/core/handle/textHandler/abortMessageHandler.py
@@ -3,6 +3,7 @@ from typing import Dict, Any
 from core.handle.abortHandle import handleAbortMessage
 from core.handle.textMessageHandler import TextMessageHandler
 from core.handle.textMessageType import TextMessageType
+from core.session.session_context import SessionContext
 
 
 class AbortTextMessageHandler(TextMessageHandler):
@@ -12,5 +13,5 @@ class AbortTextMessageHandler(TextMessageHandler):
     def message_type(self) -> TextMessageType:
         return TextMessageType.ABORT
 
-    async def handle(self, conn, msg_json: Dict[str, Any]) -> None:
+    async def handle(self, conn, msg_json: Dict[str, Any], session_context: SessionContext) -> None:
         await handleAbortMessage(conn)

--- a/main/xiaozhi-server/core/handle/textHandler/helloMessageHandler.py
+++ b/main/xiaozhi-server/core/handle/textHandler/helloMessageHandler.py
@@ -3,6 +3,7 @@ from typing import Dict, Any
 from core.handle.helloHandle import handleHelloMessage
 from core.handle.textMessageHandler import TextMessageHandler
 from core.handle.textMessageType import TextMessageType
+from core.session.session_context import SessionContext
 
 
 class HelloTextMessageHandler(TextMessageHandler):
@@ -12,5 +13,5 @@ class HelloTextMessageHandler(TextMessageHandler):
     def message_type(self) -> TextMessageType:
         return TextMessageType.HELLO
 
-    async def handle(self, conn, msg_json: Dict[str, Any]) -> None:
-        await handleHelloMessage(conn, msg_json)
+    async def handle(self, conn, msg_json: Dict[str, Any], session_context: SessionContext) -> None:
+        await handleHelloMessage(conn, msg_json, session_context)

--- a/main/xiaozhi-server/core/handle/textHandler/iotMessageHandler.py
+++ b/main/xiaozhi-server/core/handle/textHandler/iotMessageHandler.py
@@ -4,6 +4,7 @@ from typing import Dict, Any
 from core.handle.textMessageHandler import TextMessageHandler
 from core.handle.textMessageType import TextMessageType
 from core.providers.tools.device_iot import handleIotStatus, handleIotDescriptors
+from core.session.session_context import SessionContext
 
 
 class IotTextMessageHandler(TextMessageHandler):
@@ -13,7 +14,7 @@ class IotTextMessageHandler(TextMessageHandler):
     def message_type(self) -> TextMessageType:
         return TextMessageType.IOT
 
-    async def handle(self, conn, msg_json: Dict[str, Any]) -> None:
+    async def handle(self, conn, msg_json: Dict[str, Any], session_context: SessionContext) -> None:
         if "descriptors" in msg_json:
             asyncio.create_task(handleIotDescriptors(conn, msg_json["descriptors"]))
         if "states" in msg_json:

--- a/main/xiaozhi-server/core/handle/textHandler/listenMessageHandler.py
+++ b/main/xiaozhi-server/core/handle/textHandler/listenMessageHandler.py
@@ -6,6 +6,7 @@ from core.handle.reportHandle import enqueue_asr_report
 from core.handle.sendAudioHandle import send_stt_message, send_tts_message
 from core.handle.textMessageHandler import TextMessageHandler
 from core.handle.textMessageType import TextMessageType
+from core.session.session_context import SessionContext
 from core.utils.util import remove_punctuation_and_length
 
 TAG = __name__
@@ -17,7 +18,7 @@ class ListenTextMessageHandler(TextMessageHandler):
     def message_type(self) -> TextMessageType:
         return TextMessageType.LISTEN
 
-    async def handle(self, conn, msg_json: Dict[str, Any]) -> None:
+    async def handle(self, conn, msg_json: Dict[str, Any], session_context: SessionContext) -> None:
         if "mode" in msg_json:
             conn.client_listen_mode = msg_json["mode"]
             conn.logger.bind(tag=TAG).debug(

--- a/main/xiaozhi-server/core/handle/textHandler/mcpMessageHandler.py
+++ b/main/xiaozhi-server/core/handle/textHandler/mcpMessageHandler.py
@@ -4,6 +4,7 @@ from typing import Dict, Any
 from core.handle.textMessageHandler import TextMessageHandler
 from core.handle.textMessageType import TextMessageType
 from core.providers.tools.device_mcp import handle_mcp_message
+from core.session.session_context import SessionContext
 
 
 class McpTextMessageHandler(TextMessageHandler):
@@ -13,7 +14,7 @@ class McpTextMessageHandler(TextMessageHandler):
     def message_type(self) -> TextMessageType:
         return TextMessageType.MCP
 
-    async def handle(self, conn, msg_json: Dict[str, Any]) -> None:
+    async def handle(self, conn, msg_json: Dict[str, Any], session_context: SessionContext) -> None:
         if "payload" in msg_json:
             asyncio.create_task(
                 handle_mcp_message(conn, conn.mcp_client, msg_json["payload"])

--- a/main/xiaozhi-server/core/handle/textHandler/serverMessageHandler.py
+++ b/main/xiaozhi-server/core/handle/textHandler/serverMessageHandler.py
@@ -5,6 +5,7 @@ from typing import Dict, Any
 from core.handle.textMessageHandler import TextMessageHandler
 from core.handle.textMessageType import TextMessageType
 from core.providers.tools.device_mcp import handle_mcp_message
+from core.session.session_context import SessionContext
 
 TAG = __name__
 
@@ -15,7 +16,7 @@ class ServerTextMessageHandler(TextMessageHandler):
     def message_type(self) -> TextMessageType:
         return TextMessageType.SERVER
 
-    async def handle(self, conn, msg_json: Dict[str, Any]) -> None:
+    async def handle(self, conn, msg_json: Dict[str, Any], session_context: SessionContext) -> None:
         # 如果配置是从API读取的，则需要验证secret
         if not conn.read_config_from_api:
             return

--- a/main/xiaozhi-server/core/handle/textMessageHandler.py
+++ b/main/xiaozhi-server/core/handle/textMessageHandler.py
@@ -2,6 +2,7 @@ from abc import abstractmethod, ABC
 from typing import Dict, Any
 
 from core.handle.textMessageType import TextMessageType
+from core.session.session_context import SessionContext
 
 TAG = __name__
 
@@ -10,7 +11,7 @@ class TextMessageHandler(ABC):
     """消息处理器抽象基类"""
 
     @abstractmethod
-    async def handle(self, conn, msg_json: Dict[str, Any]) -> None:
+    async def handle(self, conn, msg_json: Dict[str, Any], session_context: SessionContext) -> None:
         """处理消息的抽象方法"""
         pass
 

--- a/main/xiaozhi-server/core/handle/textMessageProcessor.py
+++ b/main/xiaozhi-server/core/handle/textMessageProcessor.py
@@ -1,6 +1,7 @@
 import json
 
 from core.handle.textMessageHandlerRegistry import TextMessageHandlerRegistry
+from core.session.session_context import SessionContext
 
 TAG = __name__
 
@@ -11,11 +12,13 @@ class TextMessageProcessor:
     def __init__(self, registry: TextMessageHandlerRegistry):
         self.registry = registry
 
-    async def process_message(self, conn, message: str) -> None:
+    async def process_message(self, conn, message: str, session_context: SessionContext) -> None:
         """处理消息的主入口"""
         try:
             # 解析JSON消息
             msg_json = json.loads(message)
+
+            conn.logger.bind(tag=TAG).info(session_context.as_dict())
 
             # 处理JSON消息
             if isinstance(msg_json, dict):

--- a/main/xiaozhi-server/core/session/session_context.py
+++ b/main/xiaozhi-server/core/session/session_context.py
@@ -1,0 +1,32 @@
+import uuid
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class SessionContext:
+
+    # Session唯一标识
+    session_id: str
+
+    # 设备基本信息
+    device_id: Optional[str] = None
+    client_ip: Optional[str] = None
+
+    # 客户端状态相关
+    client_abort: Optional[bool] = False
+    client_is_speaking: Optional[bool] = False
+    client_listen_mode: Optional[str] = "auto"
+
+    last_activity_time: float = 0.0
+
+    def __init__(self, session_id: Optional[str] = None):
+        self.session_id = session_id or str(uuid.uuid4())
+
+    def __setattr__(self, key, value):
+        if hasattr(self, "session_id") and key == "session_id":
+            raise AttributeError("session_id is read-only and cannot be modified")
+        super().__setattr__(key, value)
+
+    def as_dict(self) -> dict:
+        return self.__dict__.copy()


### PR DESCRIPTION
解耦重构目前看工作量巨大，涉及前后几乎各个函数，采用分阶段逐步优化的方式，避免大范围改动导致无法测试验证，或者冲突
1. 首先实现初始化SessionContext，创建会话上下文，暂时开始作为参数注入
2. 部分参数开始由conn向SessionContext进行逐步迁移
4. conn中另外包含了许多函数需要重新设计和划分

本次先解决第一步，后面开始陆续合入第2步