### PR TITLE
修复-火山双流式语音合成-additions参数配置

### DIFF
--- a/main/xiaozhi-server/core/providers/tts/huoshan_double_stream.py
+++ b/main/xiaozhi-server/core/providers/tts/huoshan_double_stream.py
@@ -616,12 +616,13 @@ class TTSProvider(TTSProviderBase):
                             "speech_rate": self.speech_rate,
                             "loudness_rate": self.loudness_rate
                         },
+                        "additions": json.dumps({
+                            "post_process": {
+                                "pitch": self.pitch
+                            }
+                        })
                     },
-                    "additions": {
-                        "post_process": {
-                            "pitch": self.pitch
-                        }
-                    }
+
                 }
             )
         )


### PR DESCRIPTION
在使用```火山双流式语音合成```时发现在添加使用additions参数时，不生效，查阅官网文档后发现，是因为additions参数是配置在req_params下级参数中，原代码req_params和additions平级了，文档地址:https://www.volcengine.com/docs/6561/1329505