### PR TITLE
fix: Gemini代理配置使用REST传输修复gRPC不支持代理的问题

### DIFF
--- a/main/xiaozhi-server/core/providers/llm/gemini/gemini.py
+++ b/main/xiaozhi-server/core/providers/llm/gemini/gemini.py
@@ -77,6 +77,7 @@ class LLMProvider(LLMProviderBase):
         if model_key_msg:
             log.bind(tag=TAG).error(model_key_msg)
 
+        use_proxy = False
         if http_proxy or https_proxy:
             log.bind(tag=TAG).info(
                 f"检测到Gemini代理配置，开始测试代理连通性和设置代理环境..."
@@ -85,8 +86,12 @@ class LLMProvider(LLMProviderBase):
             log.bind(tag=TAG).info(
                 f"Gemini 代理设置成功 - HTTP: {http_proxy}, HTTPS: {https_proxy}"
             )
+            use_proxy = True
         # 配置API密钥
-        genai.configure(api_key=self.api_key)
+        if use_proxy:
+            genai.configure(api_key=self.api_key, transport="rest")
+        else:
+            genai.configure(api_key=self.api_key)
 
         # 设置请求超时（秒）
         self.timeout = cfg.get("timeout", 120)  # 默认120秒


### PR DESCRIPTION
  ## 问题描述
  Gemini LLM 配置代理后无法连接，连接超时。

  ## 问题原因
  Google Generative AI SDK 默认使用 gRPC 传输，不支持 HTTP_PROXY/HTTPS_PROXY 环境变量。

  ## 解决方案
  配置代理时使用 REST 传输（`transport="rest"`），REST 传输支持代理环境变量。
  未配置代理时仍使用默认 gRPC 传输，保持性能。

  ## 测试
  - ✅ 有代理：REST 传输正常工作
  - ✅ 无代理：gRPC 传输正常工作

  ## 修改内容
  - 文件：`main/xiaozhi-server/core/providers/llm/gemini/gemini.py`