### PR TITLE
feat: 为阿里百炼流式TTS支持多语言音色

### DIFF
--- a/main/manager-api/src/main/resources/db/changelog/202510141200.sql
+++ b/main/manager-api/src/main/resources/db/changelog/202510141200.sql
@@ -1,0 +1,14 @@
+-- 为阿里百炼流式语音合成添加多语言音色配置字段
+UPDATE `ai_model_provider` SET fields = '[{"key":"api_key","type":"string","label":"API密钥"},{"key":"output_dir","type":"string","label":"输出目录"},{"key":"model","type":"string","label":"模型名称"},{"key":"format","label":"音频格式","type":"string"},{"key":"sample_rate","label":"采样率","type":"number"},{"key": "volume", "type": "number", "label": "音量"},{"key": "rate", "type": "number", "label": "语速"},{"key": "pitch", "type": "number", "label": "音调"},{"key":"voice","type":"string","label":"默认音色"},{"key": "voice_zh", "type": "string", "label": "中文音色"},{"key": "voice_yue", "type": "string", "label": "粤语音色"},{"key": "voice_en", "type": "string", "label": "英语音色"},{"key": "voice_ja", "type": "string", "label": "日语音色"},{"key": "voice_ko", "type": "string", "label": "韩语音色"}]' WHERE id = 'SYSTEM_TTS_AliBLStreamTTS';
+
+-- 更新配置说明
+UPDATE `ai_model_config` SET
+`doc_link` = 'https://bailian.console.aliyun.com/?apiKey=1#/api-key',
+`remark` = '阿里百炼流式TTS说明：
+1. 访问 https://bailian.console.aliyun.com/?apiKey=1#/api-key 创建项目并获取appkey
+2. 支持实时流式合成，具有较低的延迟
+3. 支持多种音色设置和音频参数调整
+4. 使用FunASR进行语音识别时，可以自动选择对应语言音色
+5. 支持CosyVoice-V3-Flash等大模型音色，价格实惠(1元/万字符)
+6. 支持实时调节音量、语速、音调等参数
+' WHERE `id` = 'TTS_AliBLStreamTTS';

--- a/main/xiaozhi-server/config.yaml
+++ b/main/xiaozhi-server/config.yaml
@@ -846,6 +846,16 @@ TTS:
     access_key_secret: 你的阿里云账号access_key_secret
     # 截至2025年7月21日大模型音色只有北京节点采用，其他节点暂不支持
     host: nls-gateway-cn-beijing.aliyuncs.com
+    
+    # 多语言音色配置 - 根据ASR识别的语言标签自动切换音色
+    # 多语言仅限搭配FunASR SenseVoiceSmall模型使用
+    voice_zh: longxiaochun_v2   # 中文音色
+    voice_en: loongeva_v2       # 英文音色  
+    voice_yue: longjiayi_v2        # 粤语音色
+    voice_ja: oongtomoka_v2       # 日语音色
+    voice_ko: loongkyong_v2       # 韩语音色
+    default_voice: longxiaochun_v2  # 默认音色（当语言标签不匹配或无语言标签时使用）
+    
     # 以下可不用设置，使用默认设置
     # format: pcm  # 音频格式：pcm、wav、mp3
     # sample_rate: 16000  # 采样率：8000、16000、24000

--- a/main/xiaozhi-server/core/connection.py
+++ b/main/xiaozhi-server/core/connection.py
@@ -130,6 +130,7 @@ class ConnectionHandler:
         # 所以涉及到ASR的变量，需要在这里定义，属于connection的私有变量
         self.asr_audio = []
         self.asr_audio_queue = queue.Queue()
+        self.current_language_tag = None  # 存储当前ASR识别的语言标签
 
         # llm相关变量
         self.llm_finish_task = True

--- a/main/xiaozhi-server/core/handle/receiveAudioHandle.py
+++ b/main/xiaozhi-server/core/handle/receiveAudioHandle.py
@@ -1,3 +1,4 @@
+import re
 import time
 import json
 import asyncio
@@ -41,6 +42,32 @@ async def startToChat(conn, text):
     # 检查输入是否是JSON格式（包含说话人信息）
     speaker_name = None
     actual_text = text
+    language_tag = None
+
+    # 检查当前使用的ASR是否为FunASR（本地或服务版本）
+    is_funasr = False
+    if hasattr(conn, 'asr') and conn.asr:
+        asr_module = conn.asr.__class__.__module__
+        if 'fun_local' in asr_module or 'fun_server' in asr_module:
+            is_funasr = True
+            conn.logger.bind(tag=TAG).debug(f"检测到FunASR语音识别: {asr_module}")
+
+    # 只有在使用FunASR时才处理语言标签
+    if is_funasr:
+        # 检查是否包含语言标签（如<|zh|>、<|en|>等）
+        lang_pattern = r'<\|([a-z]{2,3})\|>'
+        lang_match = re.search(lang_pattern, text)
+        if lang_match:
+            language_tag = lang_match.group(1)
+            conn.current_language_tag = language_tag
+            conn.logger.bind(tag=TAG).info(f"检测到FunASR语言标签: {language_tag}")
+
+            # 移除语言标签，保留纯文本内容
+            actual_text = re.sub(lang_pattern, '', text).strip()
+            conn.logger.bind(tag=TAG).debug(f"移除语言标签后的文本: {actual_text}")
+        else:
+            # 没有检测到语言标签时，清空之前的标签
+            conn.current_language_tag = None
 
     try:
         # 尝试解析JSON格式的输入
@@ -62,6 +89,10 @@ async def startToChat(conn, text):
         conn.current_speaker = speaker_name
     else:
         conn.current_speaker = None
+
+    # 如果不是FunASR，清空语言标签，不影响其他ASR
+    if not is_funasr:
+        conn.current_language_tag = None
 
     if conn.need_bind:
         await check_bind_device(conn)

--- a/main/xiaozhi-server/core/providers/asr/fun_local.py
+++ b/main/xiaozhi-server/core/providers/asr/fun_local.py
@@ -8,8 +8,9 @@ import asyncio
 
 from config.logger import setup_logging
 from typing import Optional, Tuple, List
+from core.providers.asr.base import ASRProviderBase
+from core.providers.asr.utils import lang_tag_filter
 from funasr import AutoModel
-from funasr.utils.postprocess_utils import rich_transcription_postprocess
 from core.providers.asr.base import ASRProviderBase
 from core.providers.asr.dto.dto import InterfaceType
 
@@ -102,7 +103,9 @@ class ASRProvider(ASRProviderBase):
                     use_itn=True,
                     batch_size_s=60,
                 )
-                text = await asyncio.to_thread(rich_transcription_postprocess, result[0]["text"])
+                # text = await asyncio.to_thread(rich_transcription_postprocess, result[0]["text"])
+                # 使用lang_tag_filter处理识别结果
+                text = await asyncio.to_thread(lang_tag_filter, result[0]["text"])
                 logger.bind(tag=TAG).debug(
                     f"语音识别耗时: {time.time() - start_time:.3f}s | 结果: {text}"
                 )

--- a/main/xiaozhi-server/core/providers/asr/fun_server.py
+++ b/main/xiaozhi-server/core/providers/asr/fun_server.py
@@ -1,12 +1,12 @@
 from typing import Optional, Tuple, List
 from core.providers.asr.base import ASRProviderBase
+from core.providers.asr.utils import lang_tag_filter
 from core.providers.asr.dto.dto import InterfaceType
 import ssl
 import json
 import websockets
 from config.logger import setup_logging
 import asyncio
-import re
 
 TAG = __name__
 logger = setup_logging()
@@ -151,9 +151,13 @@ class ASRProvider(ASRProviderBase):
 
                 # Get the result from the receive task
                 result = receive_task.result()
-                match = re.match(r"<\|(.*?)\|><\|(.*?)\|><\|(.*?)\|>(.*)", result)
-                if match:
-                    result = match.group(4).strip()
+                
+                # match = re.match(r"<\|(.*?)\|><\|(.*?)\|><\|(.*?)\|>(.*)", result)
+                # if match:
+                #     result = match.group(4).strip()
+
+                # Handle language tags
+                result = lang_tag_filter(result)
                 return (
                     result,
                     file_path,

--- a/main/xiaozhi-server/core/providers/asr/utils.py
+++ b/main/xiaozhi-server/core/providers/asr/utils.py
@@ -1,0 +1,43 @@
+import re
+from config.logger import setup_logging
+
+TAG = __name__
+logger = setup_logging()
+
+
+def lang_tag_filter(text):
+    """
+    过滤函数：只保留语言标签，移除其他所有标签
+    
+    用于FunASR识别结果的处理，保留语言标签（如<|zh|>、<|en|>等），
+    但移除其他所有格式的标签（如时间戳、情感标签等）
+    
+    Args:
+        text: ASR识别的原始文本，可能包含多种标签
+        
+    Returns:
+        str: 处理后的文本，只保留语言标签（如果存在）
+        
+    Examples:
+        >>> lang_tag_filter("<|zh|><|emotion:happy|>你好")
+        '<|zh|>你好'
+        >>> lang_tag_filter("<|en|>hello world")
+        '<|en|>hello world'
+    """
+    # 定义语言标签模式
+    lang_pattern = r"<\|(zh|en|yue|ja|ko|nospeech)\|>"
+    lang_tags = re.findall(lang_pattern, text)
+
+    # 移除所有 < | ... | > 格式的标签
+    clean_text = re.sub(r"<\|.*?\|>", "", text)
+
+    # 在开头添加语言标签（如果存在）
+    if lang_tags:
+        if len(lang_tags) > 1:
+            logger.bind(tag=TAG).warning(
+                f"检测到多个语言标签: {lang_tags}，仅使用第一个: {lang_tags[0]}"
+            )
+        clean_text = f"<|{lang_tags[0]}|>{clean_text}"
+
+    return clean_text.strip()
+


### PR DESCRIPTION
[相关Issue #2109](https://github.com/xinnan-tech/xiaozhi-esp32-server/issues/2109)
实现使用FunASR SenseVoiceSmall模型 + 阿里百炼流式TTS时，支持识别说话人语言，TTS将输出对应语言。现已支持中、粤、英、日、韩。如使用其他ASR，阿里百炼流式TTS仅始终使用default_voice音色。
其它音色可从阿里百炼音色列表中获取（推荐：CosyVoiceV2/V3）后，在后台管理面板或config.yaml中修改阿里百炼流式配置。


已在test_page.html测试验证可用。

音色配置：
<img width="2530" height="1247" alt="image" src="https://github.com/user-attachments/assets/bf517f67-adb3-4519-93e0-969ba236d13f" />

粤语示例：https://github.com/user-attachments/assets/233a9d40-245c-4593-82f9-e71697c6c981


