### PR TITLE
修复注册设备接口,验证码死循环BUG

### DIFF
--- a/main/manager-api/src/main/java/xiaozhi/modules/device/controller/DeviceController.java
+++ b/main/manager-api/src/main/java/xiaozhi/modules/device/controller/DeviceController.java
@@ -72,10 +72,12 @@ public class DeviceController {
             return new Result<String>().error(ErrorCode.MCA_NOT_NULL);
         }
         // 生成六位验证码
-        String code = String.valueOf(Math.random()).substring(2, 8);
-        String key = RedisKeys.getDeviceCaptchaKey(code);
+        String code;
+        String key;
         String existsMac = null;
         do {
+            code = String.valueOf(Math.random()).substring(2, 8);
+            key = RedisKeys.getDeviceCaptchaKey(code);
             existsMac = (String) redisUtils.get(key);
         } while (StringUtils.isNotBlank(existsMac));
 


### PR DESCRIPTION
注册设备接口,原代码在生成的验证码与redis中重复时，没有重新生成验证码，会死循环，现已修复。PS:这个BUG应该挺难出现哈哈