### PR TITLE
fix:初始化ASR时,判断ASR类型取值错误修复

### DIFF
--- a/main/xiaozhi-server/core/connection.py
+++ b/main/xiaozhi-server/core/connection.py
@@ -496,7 +496,7 @@ class ConnectionHandler:
 
     def _initialize_asr(self):
         """初始化ASR"""
-        if self._asr.interface_type == InterfaceType.LOCAL:
+        if self._asr is not None and hasattr(self._asr, "interface_type") and self._asr.interface_type == InterfaceType.LOCAL:
             # 如果公共ASR是本地服务，则直接返回
             # 因为本地一个实例ASR，可以被多个连接共享
             asr = self._asr


### PR DESCRIPTION
在```xiaozhi-esp32-server/main/xiaozhi-server/core/connection.py```第434-435行代码，self._asr是传入的参数，当不希望使用本地ASR时，self._asr的值可能为None,这时调用_initialize_asr方法，会出现取值异常，修复_initialize_asr方法的取值异常：
`
def _initialize_asr(self):
        """初始化ASR"""
        if self._asr is not None and hasattr(self._asr, "interface_type") and self._asr.interface_type == InterfaceType.LOCAL:
            # 如果公共ASR是本地服务，则直接返回
            # 因为本地一个实例ASR，可以被多个连接共享
            asr = self._asr
        else:
            # 如果公共ASR是远程服务，则初始化一个新实例
            # 因为远程ASR，涉及到websocket连接和接收线程，需要每个连接一个实例
            asr = initialize_asr(self.config)

        return asr
`