### PR TITLE
update：将服务端MCP的初始化MCP服务从串行改为并发执行，并添加超时机制

### DIFF
--- a/main/xiaozhi-server/core/providers/tools/server_mcp/mcp_manager.py
+++ b/main/xiaozhi-server/core/providers/tools/server_mcp/mcp_manager.py
@@ -3,12 +3,8 @@
 import asyncio
 import os
 import json
-from datetime import timedelta
 from typing import Dict, Any, List
 
-from mcp import Implementation
-from mcp.client.session import SamplingFnT, ElicitationFnT, ListRootsFnT, LoggingFnT, MessageHandlerFnT
-from mcp.shared.session import ProgressFnT
 from mcp.types import LoggingMessageNotificationParams
 
 from config.config_loader import get_project_dir
@@ -57,8 +53,8 @@ class ServerMCPManager:
             # 初始化服务端MCP客户端
             logger.bind(tag=TAG).info(f"初始化服务端MCP客户端: {name}")
             client = ServerMCPClient(srv_config)
-            # 设置超时时间5秒
-            await asyncio.wait_for(client.initialize(logging_callback=self.logging_callback), timeout=5)
+            # 设置超时时间10秒
+            await asyncio.wait_for(client.initialize(logging_callback=self.logging_callback), timeout=10)
 
             # 使用锁保护共享状态的修改
             async with self._init_lock:


### PR DESCRIPTION
当有多个MCP服务时，改为并发后即使有一个服务没有启动或者是路径填错了其余后续的MCP服务也能正常初始化