### PR TITLE
refactor(asr): 重构speech_to_text方法以接收artifacts参数

### DIFF
--- a/main/xiaozhi-server/core/providers/asr/aliyun.py
+++ b/main/xiaozhi-server/core/providers/asr/aliyun.py
@@ -213,7 +213,7 @@ class ASRProvider(ASRProviderBase):
             return None
 
     async def speech_to_text(
-        self, opus_data: List[bytes], session_id: str, audio_format="opus"
+        self, opus_data: List[bytes], session_id: str, audio_format="opus", artifacts=None
     ) -> Tuple[Optional[str], Optional[str]]:
         """将语音数据转换为文本"""
         if self._is_token_expired():
@@ -221,7 +221,6 @@ class ASRProvider(ASRProviderBase):
             self._refresh_token()
 
         try:
-            artifacts = self.get_current_artifacts()
             if artifacts is None:
                 return "", None
             # 发送请求并获取文本

--- a/main/xiaozhi-server/core/providers/asr/aliyun_stream.py
+++ b/main/xiaozhi-server/core/providers/asr/aliyun_stream.py
@@ -341,7 +341,7 @@ class ASRProvider(ASRProviderBase):
 
         logger.bind(tag=TAG).debug("ASR会话清理完成")
 
-    async def speech_to_text(self, opus_data, session_id, audio_format):
+    async def speech_to_text(self, opus_data, session_id, audio_format, artifacts=None):
         """获取识别结果"""
         result = self.text
         self.text = ""

--- a/main/xiaozhi-server/core/providers/asr/aliyunbl_stream.py
+++ b/main/xiaozhi-server/core/providers/asr/aliyunbl_stream.py
@@ -325,7 +325,7 @@ class ASRProvider(ASRProviderBase):
 
         logger.bind(tag=TAG).debug("ASR会话清理完成")
 
-    async def speech_to_text(self, opus_data, session_id, audio_format):
+    async def speech_to_text(self, opus_data, session_id, audio_format, artifacts=None):
         """获取识别结果"""
         result = self.text
         self.text = ""

--- a/main/xiaozhi-server/core/providers/asr/baidu.py
+++ b/main/xiaozhi-server/core/providers/asr/baidu.py
@@ -30,7 +30,7 @@ class ASRProvider(ASRProviderBase):
         os.makedirs(self.output_dir, exist_ok=True)
 
     async def speech_to_text(
-        self, opus_data: List[bytes], session_id: str, audio_format="opus"
+        self, opus_data: List[bytes], session_id: str, audio_format="opus", artifacts=None
     ) -> Tuple[Optional[str], Optional[str]]:
         """将语音数据转换为文本"""
         if not opus_data:
@@ -43,7 +43,6 @@ class ASRProvider(ASRProviderBase):
                 logger.bind(tag=TAG).error("百度语音识别配置未设置，无法进行识别")
                 return None, None
 
-            artifacts = self.get_current_artifacts()
             if artifacts is None:
                 return "", None
 

--- a/main/xiaozhi-server/core/providers/asr/doubao.py
+++ b/main/xiaozhi-server/core/providers/asr/doubao.py
@@ -232,12 +232,11 @@ class ASRProvider(ASRProviderBase):
             yield data[offset:data_len], True
 
     async def speech_to_text(
-        self, opus_data: List[bytes], session_id: str, audio_format="opus"
+        self, opus_data: List[bytes], session_id: str, audio_format="opus", artifacts=None
     ) -> Tuple[Optional[str], Optional[str]]:
         """将语音数据转换为文本"""
 
         try:
-            artifacts = self.get_current_artifacts()
             if artifacts is None:
                 return "", None
 

--- a/main/xiaozhi-server/core/providers/asr/doubao_stream.py
+++ b/main/xiaozhi-server/core/providers/asr/doubao_stream.py
@@ -408,7 +408,7 @@ class ASRProvider(ASRProviderBase):
             logger.bind(tag=TAG).error(f"原始响应数据: {res.hex()}")
             raise
 
-    async def speech_to_text(self, opus_data, session_id, audio_format):
+    async def speech_to_text(self, opus_data, session_id, audio_format, artifacts=None):
         result = self.text
         self.text = ""  # 清空text
         return result, None

--- a/main/xiaozhi-server/core/providers/asr/fun_local.py
+++ b/main/xiaozhi-server/core/providers/asr/fun_local.py
@@ -64,14 +64,13 @@ class ASRProvider(ASRProviderBase):
             )
 
     async def speech_to_text(
-        self, opus_data: List[bytes], session_id: str, audio_format="opus"
+        self, opus_data: List[bytes], session_id: str, audio_format="opus", artifacts=None
     ) -> Tuple[Optional[str], Optional[str]]:
         """语音转文本主处理逻辑"""
         retry_count = 0
         
         while retry_count < MAX_RETRIES:
             try:
-                artifacts = self.get_current_artifacts()
                 if artifacts is None:
                     return "", None
 

--- a/main/xiaozhi-server/core/providers/asr/fun_server.py
+++ b/main/xiaozhi-server/core/providers/asr/fun_server.py
@@ -101,7 +101,7 @@ class ASRProvider(ASRProviderBase):
         logger.bind(tag=TAG).debug(f"Sent end message: {end_message}")
 
     async def speech_to_text(
-        self, opus_data: List[bytes], session_id: str, audio_format="opus"
+        self, opus_data: List[bytes], session_id: str, audio_format="opus", artifacts=None
     ) -> Tuple[Optional[str], Optional[str]]:
         """
         Convert speech data to text using FunASR.
@@ -109,7 +109,6 @@ class ASRProvider(ASRProviderBase):
         :param session_id: Unique session identifier.
         :return: Tuple containing recognized text and optional timestamp.
         """
-        artifacts = self.get_current_artifacts()
         
         if artifacts is None:
             return "", None

--- a/main/xiaozhi-server/core/providers/asr/openai.py
+++ b/main/xiaozhi-server/core/providers/asr/openai.py
@@ -24,10 +24,9 @@ class ASRProvider(ASRProviderBase):
     def requires_file(self) -> bool:
         return True
 
-    async def speech_to_text(self, opus_data: List[bytes], session_id: str, audio_format="opus") -> Tuple[Optional[str], Optional[str]]:
+    async def speech_to_text(self, opus_data: List[bytes], session_id: str, audio_format="opus", artifacts=None) -> Tuple[Optional[str], Optional[str]]:
         file_path = None
         try:
-            artifacts = self.get_current_artifacts()
             if artifacts is None:
                 return "", None
             file_path = artifacts.file_path

--- a/main/xiaozhi-server/core/providers/asr/qwen3_asr_flash.py
+++ b/main/xiaozhi-server/core/providers/asr/qwen3_asr_flash.py
@@ -41,13 +41,12 @@ class ASRProvider(ASRProviderBase):
         return True
 
     async def speech_to_text(
-        self, opus_data: List[bytes], session_id: str, audio_format="opus"
+        self, opus_data: List[bytes], session_id: str, audio_format="opus", artifacts=None
     ) -> Tuple[Optional[str], Optional[str]]:
         """将语音数据转换为文本"""
         temp_file_path = None
         file_path = None
         try:
-            artifacts = self.get_current_artifacts()
             if artifacts is None:
                 return "", None
             temp_file_path = artifacts.temp_path

--- a/main/xiaozhi-server/core/providers/asr/sherpa_onnx_local.py
+++ b/main/xiaozhi-server/core/providers/asr/sherpa_onnx_local.py
@@ -124,12 +124,11 @@ class ASRProvider(ASRProviderBase):
         return True
 
     async def speech_to_text(
-        self, opus_data: List[bytes], session_id: str, audio_format="opus"
+        self, opus_data: List[bytes], session_id: str, audio_format="opus", artifacts=None
     ) -> Tuple[Optional[str], Optional[str]]:
         """语音转文本主处理逻辑"""
         file_path = None
         try:
-            artifacts = self.get_current_artifacts()
             if artifacts is None:
                 return "", None
             file_path = artifacts.file_path

--- a/main/xiaozhi-server/core/providers/asr/tencent.py
+++ b/main/xiaozhi-server/core/providers/asr/tencent.py
@@ -32,7 +32,7 @@ class ASRProvider(ASRProviderBase):
         os.makedirs(self.output_dir, exist_ok=True)
 
     async def speech_to_text(
-        self, opus_data: List[bytes], session_id: str, audio_format="opus"
+        self, opus_data: List[bytes], session_id: str, audio_format="opus", artifacts=None
     ) -> Tuple[Optional[str], Optional[str]]:
         """将语音数据转换为文本"""
         if not opus_data:
@@ -45,7 +45,6 @@ class ASRProvider(ASRProviderBase):
                 logger.bind(tag=TAG).error("腾讯云语音识别配置未设置，无法进行识别")
                 return None, None
 
-            artifacts = self.get_current_artifacts()
             if artifacts is None:
                 return "", None
 

--- a/main/xiaozhi-server/core/providers/asr/vosk.py
+++ b/main/xiaozhi-server/core/providers/asr/vosk.py
@@ -44,7 +44,7 @@ class ASRProvider(ASRProviderBase):
             raise
 
     async def speech_to_text(
-        self, opus_data: List[bytes], session_id: str, audio_format="opus"
+        self, opus_data: List[bytes], session_id: str, audio_format="opus", artifacts=None
     ) -> Tuple[Optional[str], Optional[str]]:
         """将语音数据转换为文本"""
         try:
@@ -53,7 +53,6 @@ class ASRProvider(ASRProviderBase):
                 logger.bind(tag=TAG).error("VOSK模型未加载，无法进行识别")
                 return "", None
             
-            artifacts = self.get_current_artifacts()
             if artifacts is None:
                 return "", None
             if not artifacts.pcm_bytes:

--- a/main/xiaozhi-server/core/providers/asr/xunfei_stream.py
+++ b/main/xiaozhi-server/core/providers/asr/xunfei_stream.py
@@ -334,7 +334,7 @@ class ASRProvider(ASRProviderBase):
 
         logger.bind(tag=TAG).debug("ASR会话清理完成")
 
-    async def speech_to_text(self, opus_data, session_id, audio_format):
+    async def speech_to_text(self, opus_data, session_id, audio_format, artifacts=None):
         """获取识别结果"""
         result = self.text
         self.text = ""


### PR DESCRIPTION
移除各ASR提供者中重复的get_current_artifacts调用，改为通过参数传递artifacts 修改base类中process_audio方法，根据combined_pcm_data长度决定是否创建artifacts 更新所有speech_to_text方法签名，添加artifacts可选参数并更新文档字符串