### PR TITLE
Security: CORS misconfiguration allows credentialed cross-origin requests from any origin

### DIFF
--- a/main/xiaozhi-server/core/api/base_handler.py
+++ b/main/xiaozhi-server/core/api/base_handler.py
@@ -7,18 +7,28 @@ class BaseHandler:
         self.config = config
         self.logger = setup_logging()
 
-    def _add_cors_headers(self, response):
+    def _add_cors_headers(self, response, request=None):
         """添加CORS头信息"""
         response.headers["Access-Control-Allow-Headers"] = (
             "client-id, content-type, device-id, authorization"
         )
-        response.headers["Access-Control-Allow-Credentials"] = "true"
-        response.headers["Access-Control-Allow-Origin"] = "*"
+
+        trusted_origins = self.config.get("trusted_origins") or self.config.get(
+            "cors_allowed_origins"
+        ) or []
+        if isinstance(trusted_origins, str):
+            trusted_origins = [trusted_origins]
+
+        origin = request.headers.get("Origin") if request else None
+        if origin in trusted_origins:
+            response.headers["Access-Control-Allow-Origin"] = origin
+            response.headers["Access-Control-Allow-Credentials"] = "true"
+            response.headers["Vary"] = "Origin"
 
     async def handle_options(self, request):
         """处理OPTIONS请求，添加CORS头信息"""
         response = web.Response(body=b"", content_type="text/plain")
-        self._add_cors_headers(response)
+        self._add_cors_headers(response, request)
         # 添加允许的方法
         response.headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
         return response


### PR DESCRIPTION
## Problem

The API base handler sets `Access-Control-Allow-Credentials: true` together with `Access-Control-Allow-Origin: *`. Browsers treat this combination as invalid/insecure and it often leads to unsafe CORS behavior when later changed to reflected origins. This is especially risky because `authorization` is explicitly allowed in request headers.

**Severity**: `high`
**File**: `main/xiaozhi-server/core/api/base_handler.py`

## Solution

Replace wildcard origin with a strict allowlist of trusted origins and only set `Access-Control-Allow-Credentials: true` for those origins. Add `Vary: Origin` and validate origin server-side before echoing it.

## Changes

- `main/xiaozhi-server/core/api/base_handler.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
