### PR TITLE
Fix：【设备快速提示词缓存key错误】

### DIFF
--- a/main/xiaozhi-server/core/utils/prompt_manager.py
+++ b/main/xiaozhi-server/core/utils/prompt_manager.py
@@ -119,7 +119,7 @@ class PromptManager:
         # 使用传入的提示词并缓存（如果有设备ID）
         if device_id:
             device_cache_key = f"device_prompt:{device_id}"
-            self.cache_manager.set(self.CacheType.CONFIG, device_cache_key, user_prompt)
+            self.cache_manager.set(self.CacheType.DEVICE_PROMPT, device_cache_key, user_prompt)
             self.logger.bind(tag=TAG).debug(f"设备 {device_id} 的提示词已缓存")
 
         self.logger.bind(tag=TAG).info(f"使用快速提示词: {user_prompt[:50]}...")


### PR DESCRIPTION
设备提示词保存缓存时，set方法中使用的key和get方法中不一致