### PR TITLE
fix: 修复 PowerMem embedding 配置导致初始化失败

### DIFF
--- a/main/xiaozhi-server/core/providers/memory/powermem/powermem.py
+++ b/main/xiaozhi-server/core/providers/memory/powermem/powermem.py
@@ -105,18 +105,17 @@ class MemoryProvider(MemoryProviderBase):
                     embedder_config["api_key"] = config["embedding_api_key"]
                 if config.get("embedding_model"):
                     embedder_config["model"] = config["embedding_model"]
-                # Handle base_url based on provider type
-                # - qwen provider uses dashscope_base_url
-                # - openai provider uses openai_base_url
-                # Priority: embedding_xxx_base_url > embedding_base_url > xxx_base_url
+
+                # 自动修正：DashScope 的 text-embedding 模型需使用 qwen provider
+                embedding_model = config.get("embedding_model", "")
+                if embedding_provider == "openai" and "text-embedding" in embedding_model:
+                    embedding_provider = "qwen"
+
                 if embedding_provider == "qwen":
                     base_url = config.get("embedding_dashscope_base_url") or config.get("embedding_base_url")
                     if base_url:
                         embedder_config["dashscope_base_url"] = base_url
-                else:
-                    base_url = config.get("embedding_openai_base_url") or config.get("embedding_base_url")
-                    if base_url:
-                        embedder_config["openai_base_url"] = base_url
+                # openai provider 使用默认地址，不传 openai_base_url（powermem 库 bug）
 
                 powermem_config["embedder"] = {
                     "provider": embedding_provider,
@@ -313,7 +312,7 @@ class MemoryProvider(MemoryProviderBase):
 
         except Exception as e:
             logger.bind(tag=TAG).error(f"Error querying memory: {str(e)}")
-            logger.bind(tag=TAG).debug(f"Detailed error: {traceback.format_exc()}")
+            logger.bind(tag=TAG).info(f"Detailed error: {traceback.format_exc()}")
             return ""
 
     async def get_user_profile(self) -> str:


### PR DESCRIPTION
## Summary
- 修复 powermem 库 `OpenAIEmbeddingConfig` 的 `openai_base_url` 字段 Pydantic 校验报错，导致 PowerMem 完全无法初始化
- 当 `embedding_provider=openai` 但 `embedding_model` 含 `text-embedding`（DashScope 模型）时，自动切换为 `qwen` provider
- 将 `query_memory` 详细错误日志从 debug 提升为 info，便于排查

## 修复的问题
1. `openai_base_url` 字段虽在 `OpenAIEmbeddingConfig.model_fields` 中定义，但被 `extra='forbid'` 拒绝（powermem 库 bug）
2. 智控台配置 `embedding_provider=openai` + `embedding_model=text-embedding-v4` 时，实际需要走 DashScope 的 qwen provider

## Test plan
- [ ] 配置 PowerMem 使用 `embedding_provider=openai` + `embedding_model=text-embedding-v4`，确认初始化成功
- [ ] 配置 PowerMem 使用 `embedding_provider=qwen`，确认不受影响
- [ ] 确认 `query_memory` 错误时能看到详细 traceback

Related: #3053