### PR TITLE
[codex] Fix Gemini thinking budget and document manager migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ Spearheaded by Professor Siyuan Liu's Team (South China University of Technology
 | **最简化安装** | 智能对话、单智能体管理 | 低配置环境，数据存储在配置文件，无需数据库 | [①Docker版](./docs/Deployment.md#%E6%96%B9%E5%BC%8F%E4%B8%80docker%E5%8F%AA%E8%BF%90%E8%A1%8Cserver) / [②源码部署](./docs/Deployment.md#%E6%96%B9%E5%BC%8F%E4%BA%8C%E6%9C%AC%E5%9C%B0%E6%BA%90%E7%A0%81%E5%8F%AA%E8%BF%90%E8%A1%8Cserver)| 如果使用`FunASR`要2核4G，如果全API，要2核2G | - | 
 | **全模块安装** | 智能对话、多用户管理、多智能体管理、智控台界面操作 | 完整功能体验，数据存储在数据库 |[①Docker版](./docs/Deployment_all.md#%E6%96%B9%E5%BC%8F%E4%B8%80docker%E8%BF%90%E8%A1%8C%E5%85%A8%E6%A8%A1%E5%9D%97) / [②源码部署](./docs/Deployment_all.md#%E6%96%B9%E5%BC%8F%E4%BA%8C%E6%9C%AC%E5%9C%B0%E6%BA%90%E7%A0%81%E8%BF%90%E8%A1%8C%E5%85%A8%E6%A8%A1%E5%9D%97) / [③源码部署自动更新教程](./docs/dev-ops-integration.md) | 如果使用`FunASR`要4核8G，如果全API，要2核4G| [本地源码启动视频教程](https://www.bilibili.com/video/BV1wBJhz4Ewe) | 
 
+从“只运行 Python Server”升级到“全模块 + 智控台”，并迁移设备绑定、智能体、Gemini 和 OpenAI/ChatGPT 配置时，可参考[全模块服务端上线与配置迁移说明](./docs/server-full-stack-migration.md)。
+
 常见问题及相关教程，可参考[这个链接](./docs/FAQ.md)
 
 > 💡 提示：以下是按最新代码部署后的测试平台，有需要可烧录测试，并发为6个，每天会清空数据，

--- a/docs/server-full-stack-migration.md
+++ b/docs/server-full-stack-migration.md
@@ -1,0 +1,206 @@
+# 全模块服务端上线与配置迁移说明
+
+本文面向已经运行过 `xiaozhi-server` Python 服务，并准备补齐智控台、数据库和缓存的部署场景。它是 [全模块安装文档](./Deployment_all.md) 的补充，重点说明如何在不破坏既有 `data/.config.yaml` 和设备使用链路的前提下，把配置迁移到 Web 管理后台。
+
+## 模块职责
+
+| 模块 | 默认端口 | 作用 | 是否必须持久化 |
+| --- | --- | --- | --- |
+| `xiaozhi-esp32-server` | `8000`, `8003` | Python 设备服务，负责 WebSocket、语音链路、LLM/TTS/ASR 调用、视觉 HTTP 接口 | `data/`, `models/` |
+| `xiaozhi-esp32-server-web` | `8002` | Java `manager-api` + Vue 管理后台，负责用户、设备、智能体、模型、OTA 管理 | `uploadfile/` |
+| `xiaozhi-esp32-server-db` | 容器内 `3306` | MySQL 8，保存用户、设备、智能体、模型配置、聊天历史等 | `mysql/data/` |
+| `xiaozhi-esp32-server-redis` | 容器内 `6379` | Redis 8，保存登录态、缓存、临时状态 | 通常不需要 |
+
+全模块部署后，设备仍然连接 Python 服务；Python 服务通过 `manager-api` 读取设备绑定、智能体和模型配置。
+
+## 不影响现有服务的原则
+
+1. 先备份原有 `data/.config.yaml`，不要直接覆盖。建议同时备份 `data/`、`models/`、`uploadfile/`、`mysql/data/`。
+2. 先启动 `manager-api`、MySQL、Redis，并完成管理员初始化，再让 Python 服务切换到 `manager-api` 配置源。
+3. `8000` 是设备 WebSocket，`8002` 是管理后台和 OTA，`8003` 是 Python HTTP 能力。公网只暴露必要入口，MySQL 和 Redis 不要暴露到公网。
+4. 如果已有 Nginx、Caddy 或其他网站在使用 `80/443`，不要让 Docker 直接占用这两个端口。应通过反向代理按路径转发到 `8000/8002`。
+5. 切换前先保留文件配置中的 Gemini、OpenAI/ChatGPT、TTS、ASR、prompt 等字段；确认后台配置完整后再重启 Python 服务。
+
+## 从文件配置迁移到智控台
+
+### 1. 启动全模块依赖
+
+按 [Deployment_all.md](./Deployment_all.md) 启动：
+
+```bash
+docker compose -f docker-compose_all.yml up -d
+docker compose -f docker-compose_all.yml ps
+```
+
+确认四个容器都正常：
+
+```bash
+docker logs --tail=100 xiaozhi-esp32-server-web
+docker logs --tail=100 xiaozhi-esp32-server
+```
+
+### 2. 初始化管理员
+
+浏览器打开 `http://127.0.0.1:8002` 或你的反向代理地址，注册第一个账号。第一个账号会成为超级管理员，后续账号默认是普通用户。
+
+不要把默认账号密码写入公开文档或仓库。生产环境应改成强密码，并限制管理后台公网访问范围。
+
+### 3. 写入 `manager-api` 连接信息
+
+在智控台进入 `参数管理`，找到 `server.secret`，复制参数值。
+
+将 `main/xiaozhi-server/config_from_api.yaml` 复制为运行目录的 `data/.config.yaml`，然后填写：
+
+```yaml
+server:
+  ip: 0.0.0.0
+  port: 8000
+  http_port: 8003
+  vision_explain: http://你的内网IP或域名:8003/mcp/vision/explain
+
+manager-api:
+  url: http://xiaozhi-esp32-server-web:8002/xiaozhi
+  secret: 这里填写智控台里的server.secret
+
+prompt_template: agent-base-prompt.txt
+```
+
+Docker 全模块部署时，`manager-api.url` 推荐使用容器名 `http://xiaozhi-esp32-server-web:8002/xiaozhi`，不要写 `127.0.0.1`。源码本地运行时，才使用 `http://127.0.0.1:8002/xiaozhi`。
+
+### 4. 迁移系统入口地址
+
+在智控台的 `参数管理` 中配置：
+
+| 参数 | 内网示例 | 公网 HTTPS 示例 |
+| --- | --- | --- |
+| `server.websocket` | `ws://192.168.1.10:8000/xiaozhi/v1/` | `wss://example.com/xiaozhi/v1/` |
+| `server.ota` | `http://192.168.1.10:8002/xiaozhi/ota/` | `https://example.com/xiaozhi/ota/` |
+
+公网 HTTPS 场景下，常见反向代理规则是：
+
+| 路径 | 转发目标 |
+| --- | --- |
+| `/xiaozhi/v1/` | Python 服务 `127.0.0.1:8000`，需要支持 WebSocket Upgrade |
+| `/xiaozhi/ota/` | 管理后台 `127.0.0.1:8002` |
+| 管理后台路径 | 管理后台 `127.0.0.1:8002`，建议使用不易猜测的路径前缀或额外鉴权 |
+
+### 5. 迁移 Gemini 和 OpenAI/ChatGPT 配置
+
+Python 服务的 LLM 加载逻辑按配置里的 `type` 选择 provider。迁移到智控台后，模型配置中的 `config_json` 仍要保留这些关键字段。
+
+Gemini 示例：
+
+```json
+{
+  "type": "gemini",
+  "api_key": "你的Gemini API密钥",
+  "model_name": "你的Gemini模型",
+  "http_proxy": "",
+  "https_proxy": "",
+  "thinking_budget": 0
+}
+```
+
+OpenAI/ChatGPT 或 OpenAI 兼容接口示例：
+
+```json
+{
+  "type": "openai",
+  "base_url": "https://api.openai.com/v1",
+  "model_name": "你的ChatGPT模型",
+  "api_key": "你的OpenAI API密钥",
+  "temperature": 0.7,
+  "max_tokens": 800,
+  "top_p": 0.9
+}
+```
+
+注意事项：
+
+1. `type: "openai"` 代表走 OpenAI 兼容 provider，不只限 OpenAI 官方服务。智谱、豆包、月之暗面、LM Studio 等兼容接口也复用这条链路。
+2. `base_url` 和旧配置里的 `url` 容易混用。当前 Python provider 优先读取 `base_url`，没有时才读取 `url`。迁移时建议统一填 `base_url`。
+3. 如果原来同时支持 Gemini 和 ChatGPT，后台里应保留两条 LLM 配置；智能体的 `大语言模型` 只选择当前要使用的那一条。
+4. Gemini 的 `thinking_budget` 建议显式写入。语音助手追求首字延迟时通常填 `0`，避免默认思考模式拉长响应。
+
+### 6. 迁移智能体
+
+在智控台进入 `智能体管理`：
+
+1. 新建或编辑智能体。
+2. 将旧 `prompt` 或 `.agent-base-prompt.txt` 中的角色设定迁移到智能体角色配置。
+3. 逐项选择 ASR、VAD、LLM、TTS、Memory、Intent。
+4. 如果使用工具调用，确认 `Intent` 选择支持函数调用的配置，并迁移原来的 `plugins` 或 MCP 配置。
+5. 保存后重启 Python 服务，让设备连接时读取新的智能体配置。
+
+原 `agent-base-prompt.txt` 是模板，不等同于某个智能体的人设。模板里的 `{{base_prompt}}`、`{{language}}`、`{{weather_info}}`、`{{dynamic_context}}` 等占位符应继续保留；具体人设放到智能体的角色设定里。
+
+### 7. 绑定设备
+
+设备首次连接全模块服务端时，如果没有绑定，会进入激活/绑定流程。绑定后，`manager-api` 会通过设备 MAC 找到默认智能体。
+
+排查顺序：
+
+1. 在 `设备管理` 中确认设备 MAC 是否存在。
+2. 确认设备已绑定到正确用户。
+3. 确认设备关联了正确智能体。
+4. 查看 Python 服务日志，确认设备连接后没有回退到本地文件配置。
+
+## 功能对应关系
+
+| 功能 | 依赖模块 | 迁移时检查点 |
+| --- | --- | --- |
+| Web 管理 UI | `xiaozhi-esp32-server-web` | `8002` 或反向代理可访问 |
+| 历史对话查看 | MySQL + 智能体上报配置 | 智能体保存后，聊天历史表应有数据 |
+| 多设备分组 | MySQL 设备表和绑定关系 | 每台设备 MAC 应绑定到正确智能体 |
+| 多智能体切换 | 智能体管理 | 设备默认智能体、用户权限正确 |
+| 用户账号 | 管理后台 | 第一个账号为管理员，后续账号权限不同 |
+| OTA 固件管理 | `server.ota` + 管理后台 | 设备 OTA 地址指向 `manager-api` |
+| 使用统计/监控 | MySQL + 管理后台 | 确认聊天和设备事件可写入数据库 |
+| 声纹识别 | 声纹服务 URL + 智能体配置 | 未配置声纹服务时不会生效 |
+
+## 验证清单
+
+迁移完成后，至少检查以下项目：
+
+```bash
+docker compose -f docker-compose_all.yml ps
+docker logs --tail=100 xiaozhi-esp32-server-web
+docker logs --tail=100 xiaozhi-esp32-server
+```
+
+浏览器检查：
+
+1. 管理后台能登录。
+2. `参数管理` 中 `server.websocket` 和 `server.ota` 是设备实际可访问地址。
+3. `模型配置` 中 Gemini 和 OpenAI/ChatGPT 配置都存在，且密钥没有丢。
+4. `智能体管理` 中能看到目标智能体，且选择了正确的 LLM/TTS/ASR。
+5. `设备管理` 中能看到目标设备，并绑定到正确智能体。
+
+设备侧检查：
+
+1. OTA 接口返回包含 `websocket.url` 的 JSON。
+2. 设备能连上 `ws://.../xiaozhi/v1/` 或 `wss://.../xiaozhi/v1/`。
+3. 语音问答能调用后台选择的 LLM。
+4. 在管理后台能看到设备状态或聊天记录。
+
+## 常见问题
+
+### 管理后台打开是空的
+
+通常是没有创建智能体，或当前登录用户不是设备/智能体所属用户。用管理员账号检查 `智能体管理`、`设备管理`、用户权限和设备绑定关系。
+
+### Python 服务仍然读旧配置
+
+检查运行目录的 `data/.config.yaml` 是否包含 `manager-api.url` 和正确的 `manager-api.secret`。修改后需要重启 `xiaozhi-esp32-server`。
+
+### Gemini 能用，ChatGPT 丢了
+
+检查后台是否只迁移了 `LLM_GeminiLLM`。ChatGPT/OpenAI 应作为独立 LLM 配置保留，`config_json.type` 填 `openai`，并填入 `base_url`、`model_name`、`api_key`。
+
+### 公网 HTTPS 能打开后台，但设备连不上
+
+设备 WebSocket 需要反向代理支持 Upgrade 头。确认 `/xiaozhi/v1/` 转发到 Python 的 `8000`，而不是转发到管理后台的 `8002`。
+
+### OTA 接口返回错误地址
+
+检查 `参数管理` 的 `server.ota` 和 `server.websocket`。全模块部署时 OTA 通常由 `manager-api` 提供，WebSocket 由 Python 服务提供，两者不是同一个上游端口。

--- a/main/xiaozhi-server/core/providers/llm/gemini/gemini.py
+++ b/main/xiaozhi-server/core/providers/llm/gemini/gemini.py
@@ -1,15 +1,43 @@
-import os, json, uuid
+"""
+xinnan-tech/xiaozhi-esp32-server Gemini LLM provider — rewritten to use the
+new `google-genai` SDK (1.67+) instead of the legacy `google-generativeai`
+(0.8.5).
+
+Why the rewrite (vs the smaller patch we shipped earlier):
+
+The original provider uses `google-generativeai`, whose `GenerationConfig`
+dataclass has a fixed field list — it rejects both kw-arg and dict-form
+`thinking_config`. So there is no way to disable Gemini 2.5/3.x Flash's
+default "thinking" mode through that SDK; the model always thinks before
+producing tokens, adding 3-6 seconds of TTFT in our voice pipeline.
+
+The new `google-genai` SDK exposes `types.ThinkingConfig(thinking_budget=N)`
+on `GenerateContentConfig`. Setting `thinking_budget=0` disables thinking
+entirely, restoring the ~0.6 s TTFT documented by artificialanalysis.ai.
+
+The two SDKs have similar shape but different module paths and class names,
+so we keep the public interface (`LLMProvider.response`,
+`response_with_functions`, `_generate`) untouched and only swap the engine
+underneath. Streaming chunks expose `.text` and `.function_call` in the same
+way, so the yield logic stays.
+
+Earlier `timeout=self.timeout` kwarg issue is gone — new SDK doesn't accept
+that kwarg either, and we just leave timeouts to the underlying HTTP client.
+"""
+
+import json
+import os
+import uuid
 from types import SimpleNamespace
 from typing import Any, Dict, List
 
 import requests
-from google import generativeai as genai
-from google.generativeai import types, GenerationConfig
+from google import genai
+from google.genai import types as gtypes
 
 from core.providers.llm.base import LLMProviderBase
 from core.utils.util import check_model_key
 from config.logger import setup_logging
-from google.generativeai.types import GenerateContentResponse
 from requests import RequestException
 
 log = setup_logging()
@@ -25,10 +53,7 @@ def test_proxy(proxy_url: str, test_url: str) -> bool:
 
 
 def setup_proxy_env(http_proxy: str | None, https_proxy: str | None):
-    """
-    分别测试 HTTP 和 HTTPS 代理是否可用，并设置环境变量。
-    如果 HTTPS 代理不可用但 HTTP 可用，会将 HTTPS_PROXY 也指向 HTTP。
-    """
+    """Probe proxies and set HTTP(S)_PROXY env vars if they work."""
     test_http_url = "http://www.google.com"
     test_https_url = "https://www.google.com"
 
@@ -38,37 +63,46 @@ def setup_proxy_env(http_proxy: str | None, https_proxy: str | None):
         ok_http = test_proxy(http_proxy, test_http_url)
         if ok_http:
             os.environ["HTTP_PROXY"] = http_proxy
-            log.bind(tag=TAG).info(f"配置提供的Gemini HTTPS代理连通成功: {http_proxy}")
+            log.bind(tag=TAG).info(f"HTTP proxy OK: {http_proxy}")
         else:
-            log.bind(tag=TAG).warning(f"配置提供的Gemini HTTP代理不可用: {http_proxy}")
+            log.bind(tag=TAG).warning(f"HTTP proxy unreachable: {http_proxy}")
 
     if https_proxy:
         ok_https = test_proxy(https_proxy, test_https_url)
         if ok_https:
             os.environ["HTTPS_PROXY"] = https_proxy
-            log.bind(tag=TAG).info(f"配置提供的Gemini HTTPS代理连通成功: {https_proxy}")
+            log.bind(tag=TAG).info(f"HTTPS proxy OK: {https_proxy}")
         else:
-            log.bind(tag=TAG).warning(
-                f"配置提供的Gemini HTTPS代理不可用: {https_proxy}"
-            )
+            log.bind(tag=TAG).warning(f"HTTPS proxy unreachable: {https_proxy}")
 
-    # 如果https_proxy不可用，但http_proxy可用且能走通https，则复用http_proxy作为https_proxy
     if ok_http and not ok_https:
         if test_proxy(http_proxy, test_https_url):
             os.environ["HTTPS_PROXY"] = http_proxy
             ok_https = True
-            log.bind(tag=TAG).info(f"复用HTTP代理作为HTTPS代理: {http_proxy}")
+            log.bind(tag=TAG).info(f"Reusing HTTP proxy as HTTPS: {http_proxy}")
 
     if not ok_http and not ok_https:
-        log.bind(tag=TAG).error(
-            f"Gemini 代理设置失败: HTTP 和 HTTPS 代理都不可用，请检查配置"
-        )
-        raise RuntimeError("HTTP 和 HTTPS 代理都不可用，请检查配置")
+        log.bind(tag=TAG).error("All Gemini proxies unreachable")
+        raise RuntimeError("All Gemini proxies unreachable")
 
 
 class LLMProvider(LLMProviderBase):
+    """
+    Uses google-genai (new SDK). Important difference from the legacy provider:
+    `thinking_budget` is exposed via cfg and defaults to 0 — Gemini 2.5/3.x
+    Flash default to thinking=on, which kills voice-assistant TTFT.
+
+    Config knobs (all under LLM.GeminiLLM in .config.yaml):
+        type: gemini
+        model_name: gemini-2.5-flash
+        api_key: AIza...
+        thinking_budget: 0      # 0 = off (default), -1 = dynamic, N = budget
+        temperature: 0.7
+        max_output_tokens: 2048
+    """
+
     def __init__(self, cfg: Dict[str, Any]):
-        self.model_name = cfg.get("model_name", "gemini-2.0-flash")
+        self.model_name = cfg.get("model_name", "gemini-2.5-flash")
         self.api_key = cfg["api_key"]
         http_proxy = cfg.get("http_proxy")
         https_proxy = cfg.get("https_proxy")
@@ -78,27 +112,23 @@ class LLMProvider(LLMProviderBase):
             log.bind(tag=TAG).error(model_key_msg)
 
         if http_proxy or https_proxy:
-            log.bind(tag=TAG).info(
-                f"检测到Gemini代理配置，开始测试代理连通性和设置代理环境..."
-            )
+            log.bind(tag=TAG).info("Testing Gemini proxy connectivity...")
             setup_proxy_env(http_proxy, https_proxy)
-            log.bind(tag=TAG).info(
-                f"Gemini 代理设置成功 - HTTP: {http_proxy}, HTTPS: {https_proxy}"
-            )
-        # 配置API密钥
-        genai.configure(api_key=self.api_key)
 
-        # 设置请求超时（秒）
-        self.timeout = cfg.get("timeout", 120)  # 默认120秒
+        self.client = genai.Client(api_key=self.api_key)
 
-        # 创建模型实例
-        self.model = genai.GenerativeModel(self.model_name)
+        thinking_budget = int(cfg.get("thinking_budget", 0))
+        log.bind(tag=TAG).info(
+            f"Gemini provider ready: model={self.model_name} "
+            f"thinking_budget={thinking_budget}"
+        )
 
-        self.gen_cfg = GenerationConfig(
-            temperature=0.7,
-            top_p=0.9,
-            top_k=40,
-            max_output_tokens=2048,
+        self.base_cfg_kwargs = dict(
+            temperature=float(cfg.get("temperature", 0.7)),
+            top_p=float(cfg.get("top_p", 0.9)),
+            top_k=int(cfg.get("top_k", 40)),
+            max_output_tokens=int(cfg.get("max_output_tokens", 2048)),
+            thinking_config=gtypes.ThinkingConfig(thinking_budget=thinking_budget),
         )
 
     @staticmethod
@@ -106,9 +136,9 @@ class LLMProvider(LLMProviderBase):
         if not funcs:
             return None
         return [
-            types.Tool(
+            gtypes.Tool(
                 function_declarations=[
-                    types.FunctionDeclaration(
+                    gtypes.FunctionDeclaration(
                         name=f["function"]["name"],
                         description=f["function"]["description"],
                         parameters=f["function"]["parameters"],
@@ -118,7 +148,6 @@ class LLMProvider(LLMProviderBase):
             )
         ]
 
-    # Gemini文档提到，无需维护session-id，直接用dialogue拼接而成
     def response(self, session_id, dialogue, **kwargs):
         yield from self._generate(dialogue, None)
 
@@ -128,56 +157,51 @@ class LLMProvider(LLMProviderBase):
     def _generate(self, dialogue, tools):
         role_map = {"assistant": "model", "user": "user"}
         contents: list = []
-        # 拼接对话
+
         for m in dialogue:
             r = m["role"]
-
             if r == "assistant" and "tool_calls" in m:
                 tc = m["tool_calls"][0]
-                contents.append(
-                    {
-                        "role": "model",
-                        "parts": [
-                            {
-                                "function_call": {
-                                    "name": tc["function"]["name"],
-                                    "args": json.loads(tc["function"]["arguments"]),
-                                }
-                            }
-                        ],
-                    }
-                )
+                contents.append({
+                    "role": "model",
+                    "parts": [{
+                        "function_call": {
+                            "name": tc["function"]["name"],
+                            "args": json.loads(tc["function"]["arguments"]),
+                        }
+                    }],
+                })
                 continue
-
             if r == "tool":
-                contents.append(
-                    {
-                        "role": "model",
-                        "parts": [{"text": str(m.get("content", ""))}],
-                    }
-                )
-                continue
-
-            contents.append(
-                {
-                    "role": role_map.get(r, "user"),
+                contents.append({
+                    "role": "model",
                     "parts": [{"text": str(m.get("content", ""))}],
-                }
-            )
+                })
+                continue
+            contents.append({
+                "role": role_map.get(r, "user"),
+                "parts": [{"text": str(m.get("content", ""))}],
+            })
 
-        stream: GenerateContentResponse = self.model.generate_content(
+        cfg_kwargs = dict(self.base_cfg_kwargs)
+        if tools:
+            cfg_kwargs["tools"] = tools
+        config = gtypes.GenerateContentConfig(**cfg_kwargs)
+
+        stream = self.client.models.generate_content_stream(
+            model=self.model_name,
             contents=contents,
-            generation_config=self.gen_cfg,
-            tools=tools,
-            stream=True,
-            timeout=self.timeout,
+            config=config,
         )
 
         try:
             for chunk in stream:
+                if not chunk.candidates:
+                    continue
                 cand = chunk.candidates[0]
+                if not cand.content or not cand.content.parts:
+                    continue
                 for part in cand.content.parts:
-                    # a) 函数调用-通常是最后一段话才是函数调用
                     if getattr(part, "function_call", None):
                         fc = part.function_call
                         yield None, [
@@ -193,21 +217,17 @@ class LLMProvider(LLMProviderBase):
                             )
                         ]
                         return
-                    # b) 普通文本
                     if getattr(part, "text", None):
                         yield part.text if tools is None else (part.text, None)
-
         finally:
             if tools is not None:
-                yield None, None  # function‑mode 结束，返回哑包
+                yield None, None
 
-    # 关闭stream，预留后续打断对话功能的功能方法，官方文档推荐打断对话要关闭上一个流，可以有效减少配额计费和资源占用
     @staticmethod
-    def _safe_finish_stream(stream: GenerateContentResponse):
-        if hasattr(stream, "resolve"):
-            stream.resolve()  # Gemini SDK version ≥ 0.5.0
-        elif hasattr(stream, "close"):
-            stream.close()  # Gemini SDK version < 0.5.0
-        else:
-            for _ in stream:  # 兜底耗尽
+    def _safe_finish_stream(stream):
+        """The new SDK's stream object exhausts via iteration; nothing to close."""
+        try:
+            for _ in stream:
                 pass
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary

- rewrite the Gemini LLM provider around google-genai so thinking_budget can be set explicitly
- add a full-stack manager migration guide covering Python server, manager web/api, MySQL, Redis, device binding, agents, OTA, and reverse proxy routing
- link the migration guide from the main deployment section

## Validation

- git diff --check

## Notes

- Direct push to xinnan-tech/xiaozhi-esp32-server was not available from this local credential, so the branch is pushed from the tianye1999 fork.