### PR TITLE
fix(mcp): handle null JSON-RPC id without aborting the handshake

### DIFF
--- a/main/xiaozhi-server/core/providers/tools/device_mcp/mcp_handler.py
+++ b/main/xiaozhi-server/core/providers/tools/device_mcp/mcp_handler.py
@@ -128,7 +128,7 @@ async def handle_mcp_message(
     # Handle result
     if "result" in payload:
         result = payload["result"]
-        msg_id = int(payload.get("id", 0))
+        msg_id = int(payload.get("id") or 0)
 
         # Check for tool call response first
         if msg_id in mcp_client.call_results:
@@ -228,7 +228,7 @@ async def handle_mcp_message(
         error_msg = error_data.get("message", "未知错误")
         logger.bind(tag=TAG).error(f"收到MCP错误响应: {error_msg}")
 
-        msg_id = int(payload.get("id", 0))
+        msg_id = int(payload.get("id") or 0)
         if msg_id in mcp_client.call_results:
             await mcp_client.reject_call_result(
                 msg_id, Exception(f"MCP错误: {error_msg}")

--- a/main/xiaozhi-server/test/test_mcp_null_id.py
+++ b/main/xiaozhi-server/test/test_mcp_null_id.py
@@ -1,0 +1,44 @@
+"""Regression tests for null JSON-RPC ``id`` handling in the device MCP handler.
+
+JSON-RPC permits ``id`` to be ``null``. Before the fix, ``int(payload.get("id", 0))``
+only defaulted when the key was *absent*; a present ``"id": null`` reached
+``int(None)`` and raised ``TypeError``, aborting the MCP handshake and leaving the
+session with ``ready=False``. These tests assert the handler tolerates a null id.
+
+Self-contained: no conftest required.
+"""
+
+import asyncio
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from core.providers.tools.device_mcp.mcp_handler import (  # noqa: E402
+    MCPClient,
+    handle_mcp_message,
+)
+
+
+class _DummyConn:
+    """Minimal stand-in; the null-id code paths below never touch the connection."""
+
+
+def test_result_payload_with_null_id_does_not_raise():
+    client = MCPClient()
+    # Regression: a result payload whose id is JSON null must not crash.
+    asyncio.run(handle_mcp_message(_DummyConn(), client, {"result": {}, "id": None}))
+
+
+def test_error_payload_with_null_id_does_not_raise():
+    client = MCPClient()
+    # The error branch parses the id the same way and must also tolerate null.
+    asyncio.run(
+        handle_mcp_message(_DummyConn(), client, {"error": {"message": "boom"}, "id": None})
+    )
+
+
+def test_missing_id_still_defaults_to_zero():
+    client = MCPClient()
+    # The original missing-key behaviour must be preserved.
+    asyncio.run(handle_mcp_message(_DummyConn(), client, {"result": {}}))


### PR DESCRIPTION
## Problem
`id` is optional in JSON-RPC and may legitimately be `null`. In `device_mcp/mcp_handler.py`, `int(payload.get("id", 0))` only defaults when the key is **absent** — a present `"id": null` reaches `int(None)` and raises `TypeError`. The exception propagates out of the message handler, the MCP handshake never completes, and the session is left with `ready=False` (no device tools) and no clear error.

## Fix
Use `or 0` so both the missing-key and explicit-null cases collapse to `0`. Applies to the result and error branches.

## Tests
`test/test_mcp_null_id.py` — asserts the handler tolerates a null id in both result and error payloads, and that the original missing-key default is preserved.

## Risk
None — `0` was already the absent-key sentinel; this only widens it to cover `null`.
