### PR TITLE
fix(tts): pick earliest split for the first sentence, latest for the rest

### DIFF
--- a/main/xiaozhi-server/core/providers/tts/base.py
+++ b/main/xiaozhi-server/core/providers/tts/base.py
@@ -494,11 +494,16 @@ class TTSProviderBase(ABC):
         )
 
         for punct in punctuations_to_use:
-            pos = current_text.rfind(punct)
-            if (pos != -1 and last_punct_pos == -1) or (
-                pos != -1 and pos < last_punct_pos
-            ):
-                last_punct_pos = pos
+            if self.is_first_sentence:
+                # 首句取最早的标点边界，尽快产出第一段音频，降低首音延迟
+                pos = current_text.find(punct)
+                if pos != -1 and (last_punct_pos == -1 or pos < last_punct_pos):
+                    last_punct_pos = pos
+            else:
+                # 后续句取最晚的标点边界，合并为更大的分段，减少TTS调用次数
+                pos = current_text.rfind(punct)
+                if pos != -1 and pos > last_punct_pos:
+                    last_punct_pos = pos
 
         if last_punct_pos != -1:
             segment_text_raw = current_text[: last_punct_pos + 1]

--- a/main/xiaozhi-server/test/test_tts_segment_split.py
+++ b/main/xiaozhi-server/test/test_tts_segment_split.py
@@ -1,0 +1,58 @@
+"""Regression tests for ``_get_segment_text`` boundary selection.
+
+The first sentence should split at the *earliest* punctuation boundary (lowest
+time-to-first-audio); subsequent sentences should split at the *latest* boundary
+(largest chunk, fewer TTS calls). The pre-fix code used ``rfind`` for every
+sentence and kept the smallest position, which is neither.
+
+``_get_segment_text`` advances ``processed_chars`` to just past the chosen
+boundary, so asserting on ``processed_chars`` pins the boundary deterministically
+without depending on the punctuation-stripping helper.
+
+Self-contained: no conftest required.
+"""
+
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from core.providers.tts.base import TTSProviderBase  # noqa: E402
+
+
+class _StubTTS(TTSProviderBase):
+    async def text_to_speak(self, text, output_file):  # pragma: no cover - abstract stub
+        return None
+
+
+def _make(text, is_first_sentence):
+    obj = object.__new__(_StubTTS)
+    obj.tts_text_buff = [text]
+    obj.processed_chars = 0
+    obj.is_first_sentence = is_first_sentence
+    obj.tts_stop_request = False
+    obj.first_sentence_punctuations = ("，", ",", "。", "？", "?", "！", "!", "；", ";", "：")
+    obj.punctuations = ("。", "？", "?", "！", "!", "；", ";", "：")
+    return obj
+
+
+def test_first_sentence_splits_at_earliest_boundary():
+    # "a, b, c." — earliest punctuation is the first comma at index 1.
+    obj = _make("a, b, c.", is_first_sentence=True)
+    segment = obj._get_segment_text()
+    assert segment is not None
+    assert obj.processed_chars == 2  # consumed "a,"
+    assert obj.is_first_sentence is False  # flag flips after the first split
+
+
+def test_later_sentence_splits_at_latest_boundary():
+    # "one. two? three!" — latest punctuation is the trailing "!" at index 15.
+    obj = _make("one. two? three!", is_first_sentence=False)
+    segment = obj._get_segment_text()
+    assert segment is not None
+    assert obj.processed_chars == 16  # consumed the whole span up to the last "!"
+
+
+def test_no_boundary_returns_none():
+    obj = _make("no punctuation here", is_first_sentence=False)
+    assert obj._get_segment_text() is None


### PR DESCRIPTION
## Problem
In `tts/base.py`, `_get_segment_text` used `rfind` for every sentence and kept the smallest of the last-occurrence positions across the punctuation set — an inconsistent heuristic for choosing a split point.

## Fix
Differentiate by position in the reply:
- **First sentence:** take the earliest punctuation boundary (`find`) so the first audio segment is produced as soon as possible — lower time-to-first-audio.
- **Subsequent sentences:** take the latest boundary (`rfind`) so segments are as large as possible — fewer TTS calls and smoother playback.

The `tts_stop_request` flush branch is unchanged.

## Tests
`test/test_tts_segment_split.py` — asserts the first sentence splits at the earliest boundary and later sentences at the latest (pinned via `processed_chars`), plus the no-boundary case.

## Risk
Low — a correctness/latency improvement. The first-sentence-vs-rest trade-off (latency vs chunk size) is the one tuning dimension; happy to adjust if maintainers prefer different behavior.
