### PR TITLE
Security: Authentication bypass via non-null default UserDetail on auth failure

### DIFF
--- a/main/manager-api/src/main/java/xiaozhi/modules/security/user/SecurityUser.java
+++ b/main/manager-api/src/main/java/xiaozhi/modules/security/user/SecurityUser.java
@@ -26,25 +26,27 @@ public class SecurityUser {
     public static UserDetail getUser() {
         Subject subject = getSubject();
         if (subject == null) {
-            return new UserDetail();
+            return null;
         }
 
         UserDetail user = (UserDetail) subject.getPrincipal();
         if (user == null) {
-            return new UserDetail();
+            return null;
         }
 
         return user;
     }
 
     public static String getToken() {
-        return getUser().getToken();
+        UserDetail user = getUser();
+        return user != null ? user.getToken() : null;
     }
 
     /**
      * 获取用户ID
      */
     public static Long getUserId() {
-        return getUser().getId();
+        UserDetail user = getUser();
+        return user != null ? user.getId() : null;
     }
 }


### PR DESCRIPTION
## Problem

When `getSubject()` returns null (e.g., no Shiro session, expired token, or exception) or when `getPrincipal()` is null, the method returns `new UserDetail()` instead of null. This means callers performing null-check guards (e.g., `if (SecurityUser.getUser() != null)`) will believe an authenticated user exists when none does. Additionally, `getSubject()` silently swallows all exceptions and returns null, masking authentication infrastructure failures. Any downstream code relying on a null return to deny access will be bypassed with a default UserDetail object.


**Severity**: `high`
**File**: `main/manager-api/src/main/java/xiaozhi/modules/security/user/SecurityUser.java`

## Solution

Return null on authentication failure so callers can properly gate access:


## Changes

- `main/manager-api/src/main/java/xiaozhi/modules/security/user/SecurityUser.java` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
