### PR TITLE
fix(manager-api): 消除启动阶段告警

### DIFF
--- a/main/manager-api/src/main/java/xiaozhi/modules/device/dao/DeviceAddressBookDao.java
+++ b/main/manager-api/src/main/java/xiaozhi/modules/device/dao/DeviceAddressBookDao.java
@@ -13,6 +13,11 @@ import xiaozhi.modules.device.entity.DeviceAddressBookEntity;
 public interface DeviceAddressBookDao extends BaseMapper<DeviceAddressBookEntity> {
 
     /**
+     * 新增设备通讯录记录
+     */
+    int insertAddressBook(DeviceAddressBookEntity entity);
+
+    /**
      * 获取设备通讯录列表
      */
     List<DeviceAddressBookEntity> getAddressBookList(@Param("macAddress") String macAddress);

--- a/main/manager-api/src/main/java/xiaozhi/modules/device/service/impl/DeviceAddressBookServiceImpl.java
+++ b/main/manager-api/src/main/java/xiaozhi/modules/device/service/impl/DeviceAddressBookServiceImpl.java
@@ -167,7 +167,7 @@ public class DeviceAddressBookServiceImpl implements DeviceAddressBookService {
             alias = generateUniqueAlias(macAddress, targetMac, alias);
             entity.setAlias(alias);
             entity.setHasPermission(hasPermission);
-            deviceAddressBookDao.insert(entity);
+            deviceAddressBookDao.insertAddressBook(entity);
         } else {
             if (alias != null) {
                 updateAlias(macAddress, targetMac, alias);

--- a/main/manager-api/src/main/java/xiaozhi/modules/security/config/ShiroConfig.java
+++ b/main/manager-api/src/main/java/xiaozhi/modules/security/config/ShiroConfig.java
@@ -4,16 +4,19 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.apache.shiro.mgt.SecurityManager;
 import org.apache.shiro.session.mgt.SessionManager;
 import org.apache.shiro.spring.LifecycleBeanPostProcessor;
 import org.apache.shiro.spring.security.interceptor.AuthorizationAttributeSourceAdvisor;
 import org.apache.shiro.spring.web.ShiroFilterFactoryBean;
 import org.apache.shiro.web.config.ShiroFilterConfiguration;
 import org.apache.shiro.web.mgt.DefaultWebSecurityManager;
+import org.apache.shiro.web.mgt.WebSecurityManager;
 import org.apache.shiro.web.session.mgt.DefaultWebSessionManager;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Role;
 
 import jakarta.servlet.Filter;
 import xiaozhi.modules.security.oauth2.Oauth2Filter;
@@ -39,7 +42,7 @@ public class ShiroConfig {
     }
 
     @Bean("securityManager")
-    public SecurityManager securityManager(Oauth2Realm oAuth2Realm, SessionManager sessionManager) {
+    public WebSecurityManager securityManager(Oauth2Realm oAuth2Realm, SessionManager sessionManager) {
         DefaultWebSecurityManager securityManager = new DefaultWebSecurityManager();
         securityManager.setRealm(oAuth2Realm);
         securityManager.setSessionManager(sessionManager);
@@ -48,7 +51,8 @@ public class ShiroConfig {
     }
 
     @Bean("shiroFilter")
-    public ShiroFilterFactoryBean shirFilter(SecurityManager securityManager, SysParamsService sysParamsService) {
+    public static ShiroFilterFactoryBean shirFilter(@Lazy WebSecurityManager securityManager,
+            @Lazy SysParamsService sysParamsService) {
         ShiroFilterConfiguration config = new ShiroFilterConfiguration();
         config.setFilterOncePerRequest(true);
 
@@ -101,12 +105,14 @@ public class ShiroConfig {
     }
 
     @Bean("lifecycleBeanPostProcessor")
-    public LifecycleBeanPostProcessor lifecycleBeanPostProcessor() {
+    public static LifecycleBeanPostProcessor lifecycleBeanPostProcessor() {
         return new LifecycleBeanPostProcessor();
     }
 
     @Bean
-    public AuthorizationAttributeSourceAdvisor authorizationAttributeSourceAdvisor(SecurityManager securityManager) {
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+    public static AuthorizationAttributeSourceAdvisor authorizationAttributeSourceAdvisor(
+            @Lazy WebSecurityManager securityManager) {
         AuthorizationAttributeSourceAdvisor advisor = new AuthorizationAttributeSourceAdvisor();
         advisor.setSecurityManager(securityManager);
         return advisor;

--- a/main/manager-api/src/main/resources/logback-spring.xml
+++ b/main/manager-api/src/main/resources/logback-spring.xml
@@ -1,20 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <!-- 启用JansiConsoleAppender以确保控制台输出有颜色 -->
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    
-    <!-- 确保日志目录存在 -->
-    <timestamp key="bySecond" datePattern="yyyyMMdd'T'HHmmss"/>
-    
     <!-- 定义日志文件存储位置 -->
     <property name="LOG_HOME" value="./logs" />
-    
-    <!-- 使用自定义的初始化监听器确保日志目录存在 -->
-    <define name="LOGBACK_DIR_CHECK" class="ch.qos.logback.core.property.FileExistsPropertyDefiner">
-        <path>${LOG_HOME}</path>
-        <createIfMissing>true</createIfMissing>
-    </define>
-    
+
     <!-- 引入Spring Boot默认配置 -->
     <include resource="org/springframework/boot/logging/logback/defaults.xml" />
     

--- a/main/manager-api/src/main/resources/mapper/device/DeviceAddressBookDao.xml
+++ b/main/manager-api/src/main/resources/mapper/device/DeviceAddressBookDao.xml
@@ -21,7 +21,7 @@
         WHERE mac_address = #{macAddress} AND target_mac = #{targetMac}
     </update>
 
-    <insert id="insert">
+    <insert id="insertAddressBook">
         INSERT INTO ai_device_address_book (mac_address, target_mac, alias, has_permission, creator, create_date, updater, update_date)
         VALUES (#{macAddress}, #{targetMac}, #{alias}, #{hasPermission}, #{creator}, NOW(), #{updater}, NOW())
     </insert>

--- a/main/manager-api/src/test/java/xiaozhi/modules/device/service/impl/DeviceAddressBookServiceImplTest.java
+++ b/main/manager-api/src/test/java/xiaozhi/modules/device/service/impl/DeviceAddressBookServiceImplTest.java
@@ -1,0 +1,46 @@
+package xiaozhi.modules.device.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import xiaozhi.common.redis.RedisUtils;
+import xiaozhi.modules.device.dao.DeviceAddressBookDao;
+import xiaozhi.modules.device.entity.DeviceAddressBookEntity;
+import xiaozhi.modules.device.service.DeviceService;
+import xiaozhi.modules.sys.service.SysParamsService;
+
+class DeviceAddressBookServiceImplTest {
+
+    @Test
+    void newEntryUsesTheDedicatedAddressBookInsertMapping() {
+        DeviceAddressBookDao addressBookDao = mock(DeviceAddressBookDao.class);
+        RedisUtils redisUtils = mock(RedisUtils.class);
+        DeviceService deviceService = mock(DeviceService.class);
+        SysParamsService sysParamsService = mock(SysParamsService.class);
+        DeviceAddressBookServiceImpl service = new DeviceAddressBookServiceImpl(
+                addressBookDao, redisUtils, deviceService, sysParamsService);
+        when(addressBookDao.selectOne(any())).thenReturn(null);
+        when(addressBookDao.selectList(null)).thenReturn(List.of());
+
+        service.saveOrUpdate("00:11:22:33:44:55", "00:11:22:33:44:66", "living-room", true);
+
+        ArgumentCaptor<DeviceAddressBookEntity> entityCaptor = ArgumentCaptor.forClass(DeviceAddressBookEntity.class);
+        verify(addressBookDao).insertAddressBook(entityCaptor.capture());
+        DeviceAddressBookEntity entity = entityCaptor.getValue();
+        assertEquals("00:11:22:33:44:55", entity.getMacAddress());
+        assertEquals("00:11:22:33:44:66", entity.getTargetMac());
+        assertEquals("living-room", entity.getAlias());
+        assertTrue(entity.getHasPermission());
+        verify(addressBookDao, never()).insert(any(DeviceAddressBookEntity.class));
+    }
+}

--- a/main/manager-api/src/test/java/xiaozhi/modules/security/config/ShiroConfigTest.java
+++ b/main/manager-api/src/test/java/xiaozhi/modules/security/config/ShiroConfigTest.java
@@ -1,0 +1,60 @@
+package xiaozhi.modules.security.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import org.apache.shiro.session.mgt.SessionManager;
+import org.apache.shiro.spring.web.ShiroFilterFactoryBean;
+import org.apache.shiro.web.mgt.WebSecurityManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Role;
+
+import xiaozhi.modules.security.oauth2.Oauth2Realm;
+import xiaozhi.modules.sys.service.SysParamsService;
+
+class ShiroConfigTest {
+
+    @Test
+    void beanPostProcessorFactoriesDoNotInstantiateShiroConfigOrBusinessDependenciesEarly() throws Exception {
+        Method lifecycleFactory = ShiroConfig.class.getDeclaredMethod("lifecycleBeanPostProcessor");
+        Method filterFactory = ShiroConfig.class.getDeclaredMethod(
+                "shirFilter", WebSecurityManager.class, SysParamsService.class);
+
+        assertTrue(Modifier.isStatic(lifecycleFactory.getModifiers()));
+        assertTrue(BeanPostProcessor.class.isAssignableFrom(ShiroFilterFactoryBean.class));
+        assertTrue(Modifier.isStatic(filterFactory.getModifiers()));
+        Lazy securityManagerLazy = filterFactory.getParameters()[0].getAnnotation(Lazy.class);
+        Lazy sysParamsServiceLazy = filterFactory.getParameters()[1].getAnnotation(Lazy.class);
+        assertNotNull(securityManagerLazy);
+        assertNotNull(sysParamsServiceLazy);
+        assertTrue(securityManagerLazy.value());
+        assertTrue(sysParamsServiceLazy.value());
+    }
+
+    @Test
+    void authorizationAdvisorIsInfrastructureAndDefersItsSecurityManager() throws Exception {
+        Method advisorFactory = ShiroConfig.class.getDeclaredMethod(
+                "authorizationAttributeSourceAdvisor", WebSecurityManager.class);
+
+        assertTrue(Modifier.isStatic(advisorFactory.getModifiers()));
+        Lazy securityManagerLazy = advisorFactory.getParameters()[0].getAnnotation(Lazy.class);
+        assertNotNull(securityManagerLazy);
+        assertTrue(securityManagerLazy.value());
+        assertEquals(BeanDefinition.ROLE_INFRASTRUCTURE, advisorFactory.getAnnotation(Role.class).value());
+    }
+
+    @Test
+    void securityManagerRetainsTheWebSecurityContractRequiredByShiroFilter() throws Exception {
+        Method securityManagerFactory = ShiroConfig.class.getDeclaredMethod(
+                "securityManager", Oauth2Realm.class, SessionManager.class);
+
+        assertEquals(WebSecurityManager.class, securityManagerFactory.getReturnType());
+    }
+}


### PR DESCRIPTION
## 背景

#3291 的外层异常容易与启动期间出现的 57 条 BeanPostProcessorChecker 警告混淆；同时，manager-api 启动日志中还存在 Logback 配置告警和 Mapper 映射注入告警。

## 主要变更

- 将 Shiro 的 BeanPostProcessor 工厂方法改为静态方法，对相关依赖使用延迟注入，并将 authorization advisor 标记为 infrastructure。
- 删除重复或无效的 Logback converter、timestamp 和 PropertyDefiner 配置。
- 将 DeviceAddressBook 自定义 XML insert 改为独立的 insertAddressBook 映射，并更新其唯一调用方。
- 补充 ShiroConfigTest 和 DeviceAddressBookServiceImplTest，防止导致启动告警的配置形态回归。

## 影响范围

仅修改 manager-api 的 7 个文件；不升级依赖，不修改数据库结构、接口或前端。

## 验证

- 基线 → 空库 → 存量库：BeanPostProcessorChecker 为 57 → 0 → 0；converterClass deprecated、unknown property createIfMissing、DeviceAddressBookDao.insert ignoring injection 均为 1 → 0 → 0。
- 空库完成迁移并创建 30 张表；存量库显示 up-to-date。
- 两次应用启动均成功，doc 与 OpenAPI 端点均返回 HTTP 200。
- ShiroConfigTest 与 DeviceAddressBookServiceImplTest：4/4 通过。
- 完整 clean test：106 项中 104 项通过；剩余 2 项为既有 MessageSource 问题，消息码分别为 10031 和 10130。
- 编译器告警由后续 PR-B 处理，Mockito agent 告警由后续 PR-C 处理。

## Issue

关联 #3291。本 PR 不声明已经复现或关闭 Windows 报告问题。
