### PR TITLE
test(manager-api): 清理测试运行告警

### DIFF
--- a/main/manager-api/pom.xml
+++ b/main/manager-api/pom.xml
@@ -33,6 +33,7 @@
         <aliyun-sms-version>4.1.0</aliyun-sms-version>
         <okio-version>3.4.0</okio-version>
         <skipTests>true</skipTests>
+        <argLine></argLine>
     </properties>
 
     <dependencies>
@@ -287,6 +288,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <skipTests>${skipTests}</skipTests>
+                    <argLine>@{argLine} -Xshare:off -javaagent:"${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar"</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/main/manager-api/src/test/java/xiaozhi/common/service/impl/BaseServiceImplTest.java
+++ b/main/manager-api/src/test/java/xiaozhi/common/service/impl/BaseServiceImplTest.java
@@ -22,6 +22,7 @@ import java.util.function.BiFunction;
 
 import org.apache.ibatis.binding.MapperMethod;
 import org.apache.ibatis.executor.BatchResult;
+import org.apache.ibatis.logging.nologging.NoLoggingImpl;
 import org.apache.ibatis.mapping.MappedStatement;
 import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.SqlSession;
@@ -184,6 +185,10 @@ class BaseServiceImplTest {
     }
 
     private static class TestService extends BaseServiceImpl<TestMapper, TestEntity> {
+        private TestService() {
+            log = new NoLoggingImpl(TestService.class.getName());
+        }
+
         @Override
         protected String getSqlStatement(SqlMethod sqlMethod) {
             return switch (sqlMethod) {


### PR DESCRIPTION
## 主要变更

- 为 Surefire 测试进程显式配置 Mockito Java Agent。
- 仅在测试进程关闭 CDS，清理 JVM 启动提示。
- 清理批处理测试夹具产生的无事务告警。

## 验证

- 完整测试：117/117 通过
- Mockito、JVM 与无事务相关提示均为 0