### PR TITLE
fix(manager): align frontend and backend field contracts

### DIFF
--- a/main/manager-api/src/main/java/xiaozhi/modules/timbre/dto/TimbreDataDTO.java
+++ b/main/manager-api/src/main/java/xiaozhi/modules/timbre/dto/TimbreDataDTO.java
@@ -34,7 +34,7 @@ public class TimbreDataDTO {
 
     @Schema(description = "排序")
     @Min(value = 0, message = "{sort.number}")
-    private long sort;
+    private Long sort;
 
     @Schema(description = "对应 TTS 模型主键")
     @NotBlank(message = "{timbre.ttsModelId.require}")

--- a/main/manager-api/src/main/java/xiaozhi/modules/timbre/entity/TimbreEntity.java
+++ b/main/manager-api/src/main/java/xiaozhi/modules/timbre/entity/TimbreEntity.java
@@ -3,6 +3,7 @@ package xiaozhi.modules.timbre.entity;
 import java.util.Date;
 
 import com.baomidou.mybatisplus.annotation.FieldFill;
+import com.baomidou.mybatisplus.annotation.FieldStrategy;
 import com.baomidou.mybatisplus.annotation.TableField;
 import com.baomidou.mybatisplus.annotation.TableName;
 
@@ -41,7 +42,8 @@ public class TimbreEntity {
     private String referenceText;
 
     @Schema(description = "排序")
-    private long sort;
+    @TableField(updateStrategy = FieldStrategy.NOT_NULL)
+    private Long sort;
 
     @Schema(description = "对应 TTS 模型主键")
     private String ttsModelId;

--- a/main/manager-api/src/main/java/xiaozhi/modules/timbre/service/impl/TimbreServiceImpl.java
+++ b/main/manager-api/src/main/java/xiaozhi/modules/timbre/service/impl/TimbreServiceImpl.java
@@ -99,6 +99,9 @@ public class TimbreServiceImpl extends BaseServiceImpl<TimbreDao, TimbreEntity> 
     @Transactional(rollbackFor = Exception.class)
     public void save(TimbreDataDTO dto) {
         isTtsModelId(dto.getTtsModelId());
+        if (dto.getSort() == null) {
+            dto.setSort(0L);
+        }
         TimbreEntity timbreEntity = ConvertUtils.sourceToTarget(dto, TimbreEntity.class);
         baseDao.insert(timbreEntity);
     }

--- a/main/manager-api/src/main/java/xiaozhi/modules/timbre/vo/TimbreDetailsVO.java
+++ b/main/manager-api/src/main/java/xiaozhi/modules/timbre/vo/TimbreDetailsVO.java
@@ -32,7 +32,7 @@ public class TimbreDetailsVO implements Serializable {
     private String referenceText;
 
     @Schema(description = "排序")
-    private long sort;
+    private Long sort;
 
     @Schema(description = "对应 TTS 模型主键")
     private String ttsModelId;

--- a/main/manager-api/src/test/java/xiaozhi/modules/timbre/service/impl/TimbreServiceImplTest.java
+++ b/main/manager-api/src/test/java/xiaozhi/modules/timbre/service/impl/TimbreServiceImplTest.java
@@ -2,16 +2,20 @@ package xiaozhi.modules.timbre.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import xiaozhi.common.redis.RedisUtils;
 import xiaozhi.modules.timbre.dao.TimbreDao;
+import xiaozhi.modules.timbre.dto.TimbreDataDTO;
 import xiaozhi.modules.timbre.entity.TimbreEntity;
+import xiaozhi.modules.timbre.vo.TimbreDetailsVO;
 import xiaozhi.modules.voiceclone.dao.VoiceCloneDao;
 import xiaozhi.modules.voiceclone.entity.VoiceCloneEntity;
 
@@ -53,5 +57,75 @@ class TimbreServiceImplTest {
         when(timbreDao.selectById("voice-id")).thenReturn(timbre);
 
         assertNull(service.getDefaultLanguageById("voice-id"));
+    }
+
+    @Test
+    void updateLeavesSortOutOfTheUpdateWhenRequestOmitsIt() {
+        TimbreDao timbreDao = mock(TimbreDao.class);
+        RedisUtils redisUtils = mock(RedisUtils.class);
+        TimbreServiceImpl service = new TimbreServiceImpl(timbreDao, mock(VoiceCloneDao.class), redisUtils);
+        ReflectionTestUtils.setField(service, "baseDao", timbreDao);
+
+        TimbreDataDTO dto = validTimbreData();
+        service.update("voice-id", dto);
+
+        verify(timbreDao, never()).selectById("voice-id");
+        verify(timbreDao).updateById(argThat((TimbreEntity entity) ->
+                "voice-id".equals(entity.getId()) && entity.getSort() == null));
+        verify(redisUtils).delete("timbre:details:voice-id");
+    }
+
+    @Test
+    void updateUsesExplicitSortWithoutLoadingExistingTimbre() {
+        TimbreDao timbreDao = mock(TimbreDao.class);
+        TimbreServiceImpl service = new TimbreServiceImpl(
+                timbreDao, mock(VoiceCloneDao.class), mock(RedisUtils.class));
+        ReflectionTestUtils.setField(service, "baseDao", timbreDao);
+        TimbreDataDTO dto = validTimbreData();
+        dto.setSort(0L);
+
+        service.update("voice-id", dto);
+
+        verify(timbreDao, never()).selectById("voice-id");
+        verify(timbreDao).updateById(argThat((TimbreEntity entity) -> entity.getSort() == 0L));
+    }
+
+    @Test
+    void saveDefaultsOmittedSortToZero() {
+        TimbreDao timbreDao = mock(TimbreDao.class);
+        TimbreServiceImpl service = new TimbreServiceImpl(
+                timbreDao, mock(VoiceCloneDao.class), mock(RedisUtils.class));
+        ReflectionTestUtils.setField(service, "baseDao", timbreDao);
+
+        service.save(validTimbreData());
+
+        verify(timbreDao).insert(argThat((TimbreEntity entity) ->
+                "测试音色".equals(entity.getName()) && entity.getSort() == 0L));
+    }
+
+    @Test
+    void getSupportsLegacyRowsWithNullSort() {
+        TimbreDao timbreDao = mock(TimbreDao.class);
+        RedisUtils redisUtils = mock(RedisUtils.class);
+        TimbreServiceImpl service = new TimbreServiceImpl(
+                timbreDao, mock(VoiceCloneDao.class), redisUtils);
+        ReflectionTestUtils.setField(service, "baseDao", timbreDao);
+        TimbreEntity entity = new TimbreEntity();
+        entity.setId("voice-id");
+        entity.setSort(null);
+        when(timbreDao.selectById("voice-id")).thenReturn(entity);
+
+        TimbreDetailsVO details = service.get("voice-id");
+
+        assertNull(details.getSort());
+    }
+
+    private TimbreDataDTO validTimbreData() {
+        TimbreDataDTO dto = new TimbreDataDTO();
+        dto.setLanguages("中文");
+        dto.setName("测试音色");
+        dto.setTtsModelId("TTS_Test");
+        dto.setTtsVoice("test-voice");
+        return dto;
     }
 }

--- a/main/manager-mobile/package.json
+++ b/main/manager-mobile/package.json
@@ -69,7 +69,7 @@
     "build:quickapp-webview-huawei": "uni build -p quickapp-webview-huawei",
     "build:quickapp-webview-union": "uni build -p quickapp-webview-union",
     "type-check": "vue-tsc --noEmit",
-    "test:snapshot": "node --test src/pages/agent/components/agentSnapshotUtils.test.mjs src/pages/agent/components/agentSnapshotContracts.test.mjs",
+    "test:snapshot": "node --test src/pages/agent/components/agentSnapshotUtils.test.mjs src/pages/agent/components/agentSnapshotContracts.test.mjs src/pages/agent/components/voicePreviewUtils.test.mjs src/pages/device/deviceTimeUtils.test.mjs",
     "openapi-ts-request": "openapi-ts",
     "prepare": "git init && husky",
     "lint": "eslint",

--- a/main/manager-mobile/src/api/agent/agent.ts
+++ b/main/manager-mobile/src/api/agent/agent.ts
@@ -8,6 +8,7 @@ import type {
   ModelOption,
   PageData,
   RoleTemplate,
+  TtsVoice,
 } from './types'
 import { http } from '@/http/request/alova'
 
@@ -89,7 +90,7 @@ export function deleteAgent(id: string) {
 
 // 获取TTS音色列表
 export function getTTSVoices(ttsModelId: string, voiceName: string = '') {
-  return http.Get<{ id: string, name: string }[]>(`/models/${ttsModelId}/voices`, {
+  return http.Get<TtsVoice[]>(`/models/${ttsModelId}/voices`, {
     params: {
       voiceName,
     },
@@ -214,13 +215,26 @@ export function updateAgentTags(agentId: string, data) {
 
 // 获取所有语言
 export function getAllLanguage(modelId: string) {
-  return http.Get<{ id: string, name: string, languages: string }[]>(`/models/${modelId}/voices`, {
+  return http.Get<TtsVoice[]>(`/models/${modelId}/voices`, {
     meta: {
       ignoreAuth: false,
       toast: false,
     },
     cacheFor: {
       expire: 0,
+    },
+  })
+}
+
+/**
+ * 获取克隆音色的临时播放ID
+ * @param cloneId 克隆音色记录ID
+ */
+export function getVoiceCloneAudioId(cloneId: string) {
+  return http.Post<string>(`/voiceClone/audio/${cloneId}`, {}, {
+    meta: {
+      ignoreAuth: false,
+      toast: false,
     },
   })
 }

--- a/main/manager-mobile/src/api/agent/types.ts
+++ b/main/manager-mobile/src/api/agent/types.ts
@@ -114,6 +114,14 @@ export interface CorrectWordFile {
   wordCount?: number
 }
 
+export interface TtsVoice {
+  id: string
+  name: string
+  voiceDemo?: string | null
+  languages?: string | null
+  isClone?: boolean | null
+}
+
 // 角色模板数据类型
 export interface RoleTemplate {
   id: string

--- a/main/manager-mobile/src/api/device/types.ts
+++ b/main/manager-mobile/src/api/device/types.ts
@@ -7,7 +7,7 @@ export interface Device {
   id: string
   userId: string
   macAddress: string
-  lastConnectedAt: string
+  lastConnectedAtTimestamp: string | null
   autoUpdate: number
   board: string
   alias?: string

--- a/main/manager-mobile/src/pages/agent/components/voicePreviewUtils.mjs
+++ b/main/manager-mobile/src/pages/agent/components/voicePreviewUtils.mjs
@@ -1,0 +1,42 @@
+/** @param {Record<string, any>} voice */
+export function hasVoicePreview(voice) {
+  return Boolean(voice?.isClone || voice?.voiceDemo || voice?.voice_demo)
+}
+
+export function createVoicePreviewRequestGate() {
+  let sequence = 0
+
+  return {
+    begin() {
+      sequence += 1
+      return sequence
+    },
+    invalidate() {
+      sequence += 1
+    },
+    isCurrent(requestId) {
+      return requestId === sequence
+    },
+  }
+}
+
+/**
+ * @param {{ id: string, isClone?: boolean, voiceDemo?: string | null }} voice
+ * @param {(cloneId: string) => Promise<string>} getCloneAudioId
+ * @param {string} baseUrl
+ */
+export async function resolveVoicePreviewUrl(voice, getCloneAudioId, baseUrl) {
+  if (!voice?.isClone) {
+    return typeof voice?.voiceDemo === 'string' ? voice.voiceDemo : ''
+  }
+  if (!voice.id) {
+    return ''
+  }
+
+  const uuid = await getCloneAudioId(voice.id)
+  if (!uuid) {
+    return ''
+  }
+
+  return `${baseUrl.replace(/\/+$/, '')}/voiceClone/play/${encodeURIComponent(uuid)}`
+}

--- a/main/manager-mobile/src/pages/agent/components/voicePreviewUtils.test.mjs
+++ b/main/manager-mobile/src/pages/agent/components/voicePreviewUtils.test.mjs
@@ -1,0 +1,50 @@
+/* eslint-disable test/no-import-node-test -- this zero-dependency gate intentionally uses Node's built-in runner */
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createVoicePreviewRequestGate, hasVoicePreview, resolveVoicePreviewUrl } from './voicePreviewUtils.mjs'
+
+test('keeps normal voice previews on their direct URL', async () => {
+  let cloneRequestCount = 0
+  const url = await resolveVoicePreviewUrl({
+    id: 'normal-voice',
+    isClone: false,
+    voiceDemo: 'https://cdn.example.test/normal.wav',
+  }, async () => {
+    cloneRequestCount += 1
+    return 'unused'
+  }, 'https://api.example.test')
+
+  assert.equal(url, 'https://cdn.example.test/normal.wav')
+  assert.equal(cloneRequestCount, 0)
+})
+
+test('uses the clone record id to obtain and construct a temporary play URL', async () => {
+  let requestedCloneId = ''
+  const url = await resolveVoicePreviewUrl({
+    id: 'clone-record-id',
+    isClone: true,
+    voiceDemo: 'provider-speaker-id-must-not-be-played',
+  }, async (cloneId) => {
+    requestedCloneId = cloneId
+    return 'temporary uuid'
+  }, 'https://api.example.test/')
+
+  assert.equal(requestedCloneId, 'clone-record-id')
+  assert.equal(url, 'https://api.example.test/voiceClone/play/temporary%20uuid')
+})
+
+test('shows a preview control for cloned voices even without voiceDemo', () => {
+  assert.equal(hasVoicePreview({ id: 'clone-record-id', isClone: true }), true)
+  assert.equal(hasVoicePreview({ id: 'normal-voice', isClone: false, voiceDemo: '' }), false)
+})
+
+test('invalidates an older request when the same voice is cancelled and retried', () => {
+  const gate = createVoicePreviewRequestGate()
+  const firstRequest = gate.begin()
+
+  gate.invalidate()
+  const retryRequest = gate.begin()
+
+  assert.equal(gate.isCurrent(firstRequest), false)
+  assert.equal(gate.isCurrent(retryRequest), true)
+})

--- a/main/manager-mobile/src/pages/agent/edit.vue
+++ b/main/manager-mobile/src/pages/agent/edit.vue
@@ -1,12 +1,14 @@
 <script lang="ts" setup>
-import type { AgentDetail, ModelOption, PluginDefinition, RoleTemplate } from '@/api/agent/types'
+import type { AgentDetail, ModelOption, PluginDefinition, RoleTemplate, TtsVoice } from '@/api/agent/types'
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
-import { getAgentDetail, getAgentTags, getAllLanguage, getModelOptions, getPluginFunctions, getRoleTemplates, updateAgent } from '@/api/agent/agent'
+import { getAgentDetail, getAgentTags, getAllLanguage, getModelOptions, getPluginFunctions, getRoleTemplates, getVoiceCloneAudioId, updateAgent } from '@/api/agent/agent'
 import { t } from '@/i18n'
 import { usePluginStore, useProvider, useSpeedPitch } from '@/store'
+import { getEnvBaseUrl } from '@/utils'
 import { toast } from '@/utils/toast'
 import AgentSnapshotPanel from './components/AgentSnapshotPanel.vue'
 import { filterTtsVoicesByLanguage, hasUsableTtsVoiceMetadata } from './components/agentSnapshotUtils.mjs'
+import { createVoicePreviewRequestGate, hasVoicePreview, resolveVoicePreviewUrl } from './components/voicePreviewUtils.mjs'
 
 defineOptions({
   name: 'AgentEdit',
@@ -84,10 +86,20 @@ const modelOptions = ref<{
   TTS: [],
 })
 
+interface VoiceOption {
+  id?: string
+  value: string
+  name: string
+  voiceDemo?: string | null
+  voice_demo?: string | null
+  isClone: boolean
+  train_status?: number
+}
+
 // 音色选项数据
-const voiceOptions = ref<any[]>([])
+const voiceOptions = ref<VoiceOption[]>([])
 // 保存完整的音色信息
-const voiceDetails = ref<Record<string, any>>({})
+const voiceDetails = ref<Record<string, TtsVoice>>({})
 
 // 上报模式选项数据
 const reportOptions = [
@@ -139,6 +151,7 @@ interface SnapshotRestoreContext {
 // 音频播放相关
 const audioRef = ref<UniApp.InnerAudioContext | null>(null)
 const playingVoiceId = ref<string>('')
+const voicePreviewRequestGate = createVoicePreviewRequestGate()
 
 // 使用插件store
 const pluginStore = usePluginStore()
@@ -513,8 +526,8 @@ interface TtsSelectionState {
   languageTouched: boolean
   voiceTouched: boolean
   optionsModelId: string
-  voiceOptions: any[]
-  voiceDetails: Record<string, any>
+  voiceOptions: VoiceOption[]
+  voiceDetails: Record<string, TtsVoice>
   languageOptions: any[]
   displayNames: {
     tts: string
@@ -565,7 +578,7 @@ function filterVoicesByLanguage(options: VoiceSelectionOptions = {}) {
     return
   }
 
-  const allVoices = Object.values(voiceDetails.value) as any[]
+  const allVoices = Object.values(voiceDetails.value)
 
   // 根据选中的语言筛选音色
   const filteredVoices = filterTtsVoicesByLanguage(allVoices, selectedTtsLanguage.value)
@@ -624,7 +637,7 @@ async function fetchAllLanguag(ttsModelId: string, options: VoiceSelectionOption
       throw new Error('No TTS voice metadata is available')
     }
     // 保存完整的音色信息
-    voiceDetails.value = res.reduce((acc, voice) => {
+    voiceDetails.value = res.reduce<Record<string, TtsVoice>>((acc, voice) => {
       acc[voice.id] = voice
       return acc
     }, {})
@@ -863,44 +876,85 @@ function onPickerCancel(type: string) {
 }
 
 // 播放音频
-function playAudio(voiceDemo: string, voiceId: string, event: Event) {
+async function playAudio(voice: VoiceOption, event: Event) {
   event.stopPropagation() // 阻止事件冒泡，防止关闭下拉框
 
-  if (!voiceDemo) {
+  if (!hasVoicePreview(voice)) {
     return
   }
 
   // 如果正在播放同一个音频，则停止
-  if (playingVoiceId.value === voiceId) {
+  if (playingVoiceId.value === voice.value) {
     stopAudio()
     return
   }
 
   // 停止之前的音频
   stopAudio()
+  const requestId = voicePreviewRequestGate.begin()
+  playingVoiceId.value = voice.value
 
-  // 创建新的音频实例
-  audioRef.value = uni.createInnerAudioContext()
-  audioRef.value.src = voiceDemo
-  playingVoiceId.value = voiceId
+  try {
+    const audioUrl = await resolveVoicePreviewUrl({
+      id: voice.value,
+      isClone: voice.isClone,
+      voiceDemo: voice.voiceDemo || voice.voice_demo,
+    }, getVoiceCloneAudioId, getEnvBaseUrl())
 
-  // 监听播放结束
-  audioRef.value.onEnded(() => {
+    // 用户可能在等待克隆音色临时地址时取消或切换了音色。
+    if (!voicePreviewRequestGate.isCurrent(requestId) || playingVoiceId.value !== voice.value) {
+      return
+    }
+    if (!audioUrl) {
+      toast.error(t('voiceprint.getAudioFailed'))
+      playingVoiceId.value = ''
+      return
+    }
+
+    // 创建新的音频实例
+    const audio = uni.createInnerAudioContext()
+    audioRef.value = audio
+    audio.src = audioUrl
+
+    // 监听播放结束
+    audio.onEnded(() => {
+      if (
+        voicePreviewRequestGate.isCurrent(requestId)
+        && audioRef.value === audio
+        && playingVoiceId.value === voice.value
+      ) {
+        playingVoiceId.value = ''
+      }
+    })
+
+    // 监听播放错误
+    audio.onError(() => {
+      if (
+        voicePreviewRequestGate.isCurrent(requestId)
+        && audioRef.value === audio
+        && playingVoiceId.value === voice.value
+      ) {
+        toast.error(t('voiceprint.audioPlayFailed'))
+        playingVoiceId.value = ''
+      }
+    })
+
+    // 播放音频
+    audio.play()
+  }
+  catch (error) {
+    if (!voicePreviewRequestGate.isCurrent(requestId) || playingVoiceId.value !== voice.value) {
+      return
+    }
+    console.error('获取克隆音色试听地址失败:', error)
+    toast.error(t('voiceprint.getAudioFailed'))
     playingVoiceId.value = ''
-  })
-
-  // 监听播放错误
-  audioRef.value.onError(() => {
-    toast.error('音频播放失败')
-    playingVoiceId.value = ''
-  })
-
-  // 播放音频
-  audioRef.value.play()
+  }
 }
 
 // 停止音频
 function stopAudio() {
+  voicePreviewRequestGate.invalidate()
   if (audioRef.value) {
     audioRef.value.stop()
     audioRef.value.destroy()
@@ -1592,10 +1646,10 @@ onMounted(async () => {
             class="flex items-center justify-between border-b border-[#f5f5f5] p-[32rpx] transition-all active:bg-[#f5f7fb]"
             @click="onPickerConfirm('voiceprint', voice.value, voice.name)"
           >
-            <text :class="`flex-1 text-[28rpx] text-[#232338] ${(voice.voiceDemo || voice.voice_demo) ? '' : 'text-center'}`">
+            <text :class="`flex-1 text-[28rpx] text-[#232338] ${hasVoicePreview(voice) ? '' : 'text-center'}`">
               {{ voice.name }}
             </text>
-            <view v-if="voice.voiceDemo || voice.voice_demo" class="ml-[20rpx]" @click.stop="playAudio(voice.voiceDemo || voice.voice_demo, voice.value, $event)">
+            <view v-if="hasVoicePreview(voice)" class="ml-[20rpx]" @click.stop="playAudio(voice, $event)">
               <wd-icon
                 :name="playingVoiceId === voice.value ? 'pause-circle' : 'play-circle'"
                 size="24px"

--- a/main/manager-mobile/src/pages/device/deviceTimeUtils.mjs
+++ b/main/manager-mobile/src/pages/device/deviceTimeUtils.mjs
@@ -1,0 +1,14 @@
+/** @param {unknown} timestamp */
+export function parseDeviceLastConnectedAtTimestamp(timestamp) {
+  if (typeof timestamp !== 'string' || !timestamp.trim()) {
+    return null
+  }
+
+  const milliseconds = Number(timestamp)
+  if (!Number.isFinite(milliseconds)) {
+    return null
+  }
+
+  const date = new Date(milliseconds)
+  return Number.isNaN(date.getTime()) ? null : date
+}

--- a/main/manager-mobile/src/pages/device/deviceTimeUtils.test.mjs
+++ b/main/manager-mobile/src/pages/device/deviceTimeUtils.test.mjs
@@ -1,0 +1,15 @@
+/* eslint-disable test/no-import-node-test -- this zero-dependency gate intentionally uses Node's built-in runner */
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { parseDeviceLastConnectedAtTimestamp } from './deviceTimeUtils.mjs'
+
+test('parses the backend Long timestamp serialized as a string', () => {
+  const timestamp = '1783689702000'
+  assert.equal(parseDeviceLastConnectedAtTimestamp(timestamp)?.getTime(), Number(timestamp))
+})
+
+test('rejects missing and malformed device timestamps', () => {
+  assert.equal(parseDeviceLastConnectedAtTimestamp(null), null)
+  assert.equal(parseDeviceLastConnectedAtTimestamp(''), null)
+  assert.equal(parseDeviceLastConnectedAtTimestamp('not-a-timestamp'), null)
+})

--- a/main/manager-mobile/src/pages/device/index.vue
+++ b/main/manager-mobile/src/pages/device/index.vue
@@ -5,6 +5,7 @@ import { useMessage } from 'wot-design-uni/components/wd-message-box'
 import { bindDevice, bindDeviceManual, getBindDevices, getFirmwareTypes, unbindDevice, updateDeviceAutoUpdate } from '@/api/device'
 import { t } from '@/i18n'
 import { toast } from '@/utils/toast'
+import { parseDeviceLastConnectedAtTimestamp } from './deviceTimeUtils.mjs'
 
 defineOptions({
   name: 'DeviceManage',
@@ -131,10 +132,10 @@ function getDeviceTypeName(boardKey: string): string {
 }
 
 // 格式化时间
-function formatTime(timeStr: string) {
-  if (!timeStr)
+function formatTime(timestamp: string | null) {
+  const date = parseDeviceLastConnectedAtTimestamp(timestamp)
+  if (!date)
     return t('device.neverConnected')
-  const date = new Date(timeStr)
   const now = new Date()
   const diff = now.getTime() - date.getTime()
 
@@ -410,7 +411,7 @@ defineExpose({
                       {{ t('device.firmwareVersion') }}：{{ device.appVersion }}
                     </text>
                     <text class="block text-[28rpx] text-[#65686f] leading-[1.4]">
-                      {{ t('device.lastConnection') }}：{{ formatTime(device.lastConnectedAt) }}
+                      {{ t('device.lastConnection') }}：{{ formatTime(device.lastConnectedAtTimestamp) }}
                     </text>
                   </view>
 

--- a/main/manager-web/src/apis/module/correctWord.js
+++ b/main/manager-web/src/apis/module/correctWord.js
@@ -27,7 +27,7 @@ export default {
     getFileList(params, callback) {
         const queryParams = new URLSearchParams({
             page: params.page,
-            pageSize: params.pageSize
+            limit: params.pageSize
         }).toString();
 
         RequestService.sendRequest()

--- a/main/manager-web/src/apis/module/timbre.js
+++ b/main/manager-web/src/apis/module/timbre.js
@@ -79,6 +79,7 @@ export default {
                 remark: params.remark,
                 referenceAudio: params.referenceAudio,
                 referenceText: params.referenceText,
+                sort: params.sort,
                 ttsModelId: params.ttsModelId,
                 ttsVoice: params.voiceCode,
                 voiceDemo: params.voiceDemo || ''

--- a/main/manager-web/src/views/AddressBookManagement.vue
+++ b/main/manager-web/src/views/AddressBookManagement.vue
@@ -141,23 +141,24 @@
                 <p class="section-desc">{{ $t('addressBookManagement.setPermissionDesc', { count: selectedPermissions.length }) }}</p>
               </div>
               <div class="section-actions">
-                <CustomButton size="small" @click="handleCancel">{{ $t('common.cancel') }}</CustomButton>
-                <CustomButton size="small" @click="handleToggleSelectAll">{{ isAllSelected ? $t('addressBookManagement.deselectAll') : $t('addressBookManagement.selectAll') }}</CustomButton>
-                <CustomButton type="confirm" size="small" @click="handleSavePermissions">{{ $t('addressBookManagement.save') }}</CustomButton>
+                <CustomButton size="small" :disabled="permissionsLoading" @click="handleCancel">{{ $t('common.cancel') }}</CustomButton>
+                <CustomButton size="small" :disabled="permissionsLoading" @click="handleToggleSelectAll">{{ isAllSelected ? $t('addressBookManagement.deselectAll') : $t('addressBookManagement.selectAll') }}</CustomButton>
+                <CustomButton type="confirm" size="small" :disabled="permissionsLoading" @click="handleSavePermissions">{{ $t('addressBookManagement.save') }}</CustomButton>
               </div>
             </div>
 
-            <div class="permission-grid">
+            <div v-loading="permissionsLoading" class="permission-grid">
               <div
                 v-for="device in allDevices"
                 :key="device.id"
                 class="permission-item"
-                :class="{ active: selectedPermissions.includes(device.id) }"
+                :class="{ active: selectedPermissions.includes(device.deviceId) }"
               >
                 <el-checkbox
                   class="permission-checkbox"
-                  :value="selectedPermissions.includes(device.id)"
-                  @change="(checked) => handlePermissionToggle(device.id, checked)"
+                  :disabled="permissionsLoading"
+                  :value="selectedPermissions.includes(device.deviceId)"
+                  @change="(checked) => handlePermissionToggle(device.deviceId, checked)"
                 ></el-checkbox>
                 <div class="permission-avatar">
                   <img :src="getDeviceAvatar(device.id)" alt="avatar" />
@@ -229,7 +230,9 @@ export default {
       editAgentNameValue: '',
       editingDeviceId: null,
       editingDeviceName: '',
-      mqttServiceAvailable: false
+      mqttServiceAvailable: false,
+      permissionRequestSequence: 0,
+      permissionsLoading: false
     };
   },
   created() {
@@ -363,18 +366,45 @@ export default {
       this.loadAddressBookPermissions(device.deviceId);
     },
     loadAddressBookPermissions(macAddress) {
+      const requestId = ++this.permissionRequestSequence;
+      this.permissionsLoading = true;
+      this.selectedPermissions = [];
+      this.originalPermissions = [];
+      this.editingDeviceId = null;
+      this.editingDeviceName = '';
+      this.allDevices.forEach(device => {
+        device.addressBookAlias = '';
+      });
       AddressBookApi.getAddressBookList(macAddress, (res) => {
+        if (
+          requestId !== this.permissionRequestSequence ||
+          this.selectedDevice?.deviceId !== macAddress
+        ) {
+          return;
+        }
+        this.permissionsLoading = false;
         if (res.data?.code === 0) {
           const permissions = res.data.data || [];
+          const permissionsByTargetMac = new Map(
+            permissions.map(permission => [
+              (permission.targetMac || '').toLowerCase(),
+              permission
+            ])
+          );
           // 设置已选择的权限
-          this.selectedPermissions = permissions
-            .filter(p => p.hasPermission)
-            .map(p => p.targetMac);
+          const permittedTargetMacs = new Set(
+            permissions
+              .filter(p => p.hasPermission)
+              .map(p => (p.targetMac || '').toLowerCase())
+          );
+          this.selectedPermissions = this.allDevices
+            .filter(device => permittedTargetMacs.has((device.deviceId || '').toLowerCase()))
+            .map(device => device.deviceId);
           // 保存初始权限状态（用于对比变更）
           this.originalPermissions = [...this.selectedPermissions];
           // 更新设备的通讯录别名
           this.allDevices.forEach(device => {
-            const addrBook = permissions.find(p => p.targetMac === device.deviceId);
+            const addrBook = permissionsByTargetMac.get((device.deviceId || '').toLowerCase());
             if (addrBook) {
               device.addressBookAlias = addrBook.alias || '';
             } else {
@@ -385,6 +415,7 @@ export default {
       });
     },
     handleStartEditPermission(device) {
+      if (this.permissionsLoading) return;
       this.editingDeviceId = device.id;
       this.editingDeviceName = device.addressBookAlias || device.name;
       this.$nextTick(() => {
@@ -412,13 +443,14 @@ export default {
       this.editingDeviceId = null;
       this.editingDeviceName = '';
     },
-    handlePermissionToggle(deviceId, checked) {
+    handlePermissionToggle(targetMac, checked) {
+      if (this.permissionsLoading) return;
       if (checked) {
-        if (!this.selectedPermissions.includes(deviceId)) {
-          this.selectedPermissions.push(deviceId);
+        if (!this.selectedPermissions.includes(targetMac)) {
+          this.selectedPermissions.push(targetMac);
         }
       } else {
-        const index = this.selectedPermissions.indexOf(deviceId);
+        const index = this.selectedPermissions.indexOf(targetMac);
         if (index > -1) {
           this.selectedPermissions.splice(index, 1);
         }
@@ -428,21 +460,22 @@ export default {
       if (this.isAllSelected) {
         this.selectedPermissions = [];
       } else {
-        this.selectedPermissions = this.allDevices.map(d => d.id);
+        this.selectedPermissions = this.allDevices.map(d => d.deviceId);
       }
     },
     handleCancel() {
       this.selectedPermissions = [];
     },
     handleSavePermissions() {
+      if (this.permissionsLoading) return;
       const promises = this.allDevices
         .filter(device => {
-          const isNowSelected = this.selectedPermissions.includes(device.id);
-          const wasOriginallySelected = this.originalPermissions.includes(device.id);
+          const isNowSelected = this.selectedPermissions.includes(device.deviceId);
+          const wasOriginallySelected = this.originalPermissions.includes(device.deviceId);
           return isNowSelected !== wasOriginallySelected;
         })
         .map(device => {
-          const hasPermission = this.selectedPermissions.includes(device.id);
+          const hasPermission = this.selectedPermissions.includes(device.deviceId);
           return new Promise((resolve) => {
             AddressBookApi.updatePermission({
               macAddress: this.selectedDevice.deviceId,

--- a/main/manager-web/tests/frontendContract.test.mjs
+++ b/main/manager-web/tests/frontendContract.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const addressBookSource = await readFile(
+  new URL('../src/views/AddressBookManagement.vue', import.meta.url),
+  'utf8',
+);
+const correctWordApiSource = await readFile(
+  new URL('../src/apis/module/correctWord.js', import.meta.url),
+  'utf8',
+);
+
+test('address-book permission state consistently uses the target device MAC', () => {
+  assert.match(
+    addressBookSource,
+    /:value="selectedPermissions\.includes\(device\.deviceId\)"/,
+  );
+  assert.match(
+    addressBookSource,
+    /@change="\(checked\) => handlePermissionToggle\(device\.deviceId, checked\)"/,
+  );
+  assert.match(
+    addressBookSource,
+    /this\.selectedPermissions = this\.allDevices\.map\(d => d\.deviceId\)/,
+  );
+  assert.match(
+    addressBookSource,
+    /this\.originalPermissions\.includes\(device\.deviceId\)/,
+  );
+  assert.doesNotMatch(
+    addressBookSource,
+    /selectedPermissions\.includes\(device\.id\)/,
+  );
+  assert.doesNotMatch(
+    addressBookSource,
+    /originalPermissions\.includes\(device\.id\)/,
+  );
+  assert.match(
+    addressBookSource,
+    /requestId !== this\.permissionRequestSequence/,
+  );
+  assert.match(
+    addressBookSource,
+    /this\.selectedDevice\?\.deviceId !== macAddress/,
+  );
+  assert.match(
+    addressBookSource,
+    /this\.permissionsLoading = true;\s*this\.selectedPermissions = \[\];\s*this\.originalPermissions = \[\];/,
+  );
+  assert.match(
+    addressBookSource,
+    /handleSavePermissions\(\) \{\s*if \(this\.permissionsLoading\) return;/,
+  );
+});
+
+test('correct-word pagination maps the UI page size to the backend limit query', () => {
+  assert.match(
+    correctWordApiSource,
+    /new URLSearchParams\(\{\s*page: params\.page,\s*limit: params\.pageSize\s*\}\)/,
+  );
+  assert.doesNotMatch(correctWordApiSource, /pageSize: params\.pageSize/);
+});

--- a/main/manager-web/tests/timbreContract.test.mjs
+++ b/main/manager-web/tests/timbreContract.test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const timbreApiSource = await readFile(
+  new URL('../src/apis/module/timbre.js', import.meta.url),
+  'utf8',
+);
+
+test('timbre update sends the current sort value to the backend', () => {
+  const updateStart = timbreApiSource.indexOf('updateVoice(params, callback)');
+
+  assert.notEqual(updateStart, -1);
+  const updateSource = timbreApiSource.slice(updateStart);
+  assert.match(updateSource, /\.method\('PUT'\)/);
+  assert.match(updateSource, /sort:\s*params\.sort/);
+});


### PR DESCRIPTION
## 背景

参考 #3301，对管理端前后端字段契约做同类排查后，修复 5 处已确认的不一致。

## 修复内容

- 通讯录权限状态统一使用目标设备 MAC，不再混用数据库 UUID；同时规范化 MAC 大小写，并拦截设备快速切换时的旧响应和加载期误操作。
- 替换词文件列表把页面的 pageSize 映射为后端分页参数 limit。
- 移动端设备列表改用后端返回的 lastConnectedAtTimestamp 毫秒字符串，并处理空值和非法值。
- 移动端克隆音色试听先使用克隆记录 ID 获取临时 UUID，再构造播放地址；普通音色继续使用直链，并处理取消、切换及同音色重试竞态。
- Web 更新音色时携带 sort；后端将 sort 契约改为可空包装类型，省略时通过单条 UPDATE 原子保留原值，显式 0 正常写入，并兼容历史 NULL 数据。

## 修复前复现

1. 通讯录中给另一设备授权后重新进入页面，授权勾选状态不正确，取消授权也可能不生效。
2. 替换词文件数量超过一页时，切换每页条数，请求仍使用后端不识别的 pageSize。
3. 移动端设备页打开已连接设备，最后连接时间显示为从未连接。
4. 移动端智能体编辑页试听克隆音色，会把供应商 speaker_id 当作 URL 播放并失败。
5. 管理端编辑音色排序并保存，更新请求遗漏 sort，排序无法可靠保存。

## 验证

- Manager API：全量 Maven 测试 126/126 通过。
- Manager Web：单元测试 8/8、快照测试 13/13、生产构建通过。
- Manager Mobile：标准测试 20/20、vue-tsc 类型检查、目标文件 ESLint、H5 生产构建通过。
- git diff --check 通过。
- 独立代码审查未发现 P0-P3 可操作问题。