### PR TITLE
fix(manager-web): keep function dialog footer accessible with many MCP tools

### DIFF
--- a/main/manager-web/src/components/FunctionDialog.vue
+++ b/main/manager-web/src/components/FunctionDialog.vue
@@ -656,6 +656,7 @@ export default {
 .drawer-footer {
   position: absolute;
   bottom: 0;
+  z-index: 2;
   width: 100%;
   border-top: 1px solid #e8e8e8;
   padding: 10px 16px;

--- a/main/manager-web/tests/frontendContract.test.mjs
+++ b/main/manager-web/tests/frontendContract.test.mjs
@@ -10,6 +10,10 @@ const correctWordApiSource = await readFile(
   new URL('../src/apis/module/correctWord.js', import.meta.url),
   'utf8',
 );
+const functionDialogSource = await readFile(
+  new URL('../src/components/FunctionDialog.vue', import.meta.url),
+  'utf8',
+);
 
 test('address-book permission state consistently uses the target device MAC', () => {
   assert.match(
@@ -60,4 +64,17 @@ test('correct-word pagination maps the UI page size to the backend limit query',
     /new URLSearchParams\(\{\s*page: params\.page,\s*limit: params\.pageSize\s*\}\)/,
   );
   assert.doesNotMatch(correctWordApiSource, /pageSize: params\.pageSize/);
+});
+
+test('function dialog footer stays above the expanding MCP tools section', () => {
+  const mcpLayer = functionDialogSource.match(
+    /\.mcp-access-point\s*\{[^}]*z-index:\s*(\d+);/s,
+  );
+  const footerLayer = functionDialogSource.match(
+    /\.drawer-footer\s*\{[^}]*z-index:\s*(\d+);/s,
+  );
+
+  assert.ok(mcpLayer, 'MCP section should define its stacking layer');
+  assert.ok(footerLayer, 'drawer footer should define its stacking layer');
+  assert.ok(Number(footerLayer[1]) > Number(mcpLayer[1]));
 });


### PR DESCRIPTION
## Summary

- keep the function-management drawer footer above an expanding MCP tool list
- add a frontend contract test that guards the footer/MCP stacking relationship

## Root cause

The MCP access-point section has `z-index: 1`, while the absolutely positioned drawer footer used the default stacking level. When enough MCP tool buttons wrapped onto additional rows, the MCP section overlapped the footer and intercepted clicks intended for **Save configuration**.

## User impact

Agents connected to MCP servers exposing many tools could not save their function configuration without first disabling or reducing those tools.

## Verification

- `npm run test:unit` — 9 tests passed
- `npm run test:snapshot` — 13 tests passed
- `npm run check:i18n` — 6 locale files passed
- `npm run build` — production build completed; only existing asset-size and precache warnings were reported
- browser regression with 15 MCP tools: before the change the save-button hit target was `.mcp-right`; with the new footer layer the button received the hit at 1440, 1024, 768, and 320 pixel widths
- the temporary MCP server used for reproduction was disabled again after verification
