### PR TITLE
fix(tts): SiliconFlow provider 增加请求超时与 HTTP 错误处理

### DIFF
--- a/main/xiaozhi-server/core/providers/tts/siliconflow.py
+++ b/main/xiaozhi-server/core/providers/tts/siliconflow.py
@@ -39,8 +39,13 @@ class TTSProvider(TTSProviderBase):
         }
         try:
             response = requests.request(
-                "POST", self.api_url, json=request_json, headers=headers
+                "POST", self.api_url, json=request_json, headers=headers,
+                timeout=15,
             )
+            if response.status_code != 200:
+                raise Exception(
+                    f"{__name__} HTTP {response.status_code}: {response.text[:200]}"
+                )
             data = response.content
             if output_file:
                 with open(output_file, "wb") as file_to_save:

--- a/main/xiaozhi-server/core/providers/tts/siliconflow.py
+++ b/main/xiaozhi-server/core/providers/tts/siliconflow.py
@@ -40,7 +40,7 @@ class TTSProvider(TTSProviderBase):
         try:
             response = requests.request(
                 "POST", self.api_url, json=request_json, headers=headers,
-                timeout=15,
+                timeout=self.tts_timeout,
             )
             if response.status_code != 200:
                 raise Exception(


### PR DESCRIPTION
## 问题

`core/providers/tts/siliconflow.py` 中的 `requests.request()` **没有设置 timeout**：

1. **请求无限挂起**：当 SiliconFlow API 响应变慢时，请求会一直挂住，设备表现为"时好时坏、有时没有声音"（服务端日志无报错，极难排查）
2. **错误页被当音频**：非 200 响应（限流、错误页等）的内容会被直接写入音频文件，导致播放错误内容

## 修复

- 所有请求添加 `timeout=15`
- 检查 `status_code`，非 200 时抛出包含响应正文的异常，不再把错误页当音频写盘

## 验证

- 修复后连续多轮对话，服务端日志稳定输出 `语音生成成功`
- API 超时/错误场景下异常正确抛出，请求不再无限挂起

## 备注

该问题在 0.5.7 与当前 main 分支均存在。