### PR TITLE
fix(tts): 统一 TTS 请求超时配置

### DIFF
--- a/main/manager-api/src/main/resources/db/changelog/202608131030.sql
+++ b/main/manager-api/src/main/resources/db/changelog/202608131030.sql
@@ -1,0 +1,4 @@
+UPDATE `sys_params`
+SET `param_value` = '15'
+WHERE `param_code` = 'tts_timeout'
+  AND `param_value` = '10';

--- a/main/manager-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/main/manager-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -725,3 +725,10 @@ databaseChangeLog:
         - sqlFile:
             encoding: utf8
             path: classpath:db/changelog/202608061030.sql
+  - changeSet:
+      id: 202608131030
+      author: tykechen
+      changes:
+        - sqlFile:
+            encoding: utf8
+            path: classpath:db/changelog/202608131030.sql

--- a/main/xiaozhi-server/config.yaml
+++ b/main/xiaozhi-server/config.yaml
@@ -60,7 +60,7 @@ delete_audio: true
 # 没有语音输入多久后断开连接(秒)，默认2分钟，即120秒
 close_connection_no_voice_time: 120
 # TTS请求超时时间(秒)
-tts_timeout: 10
+tts_timeout: 15
 # 工具调用超时时间(秒)
 tool_call_timeout: 30
 # 开启唤醒词加速

--- a/main/xiaozhi-server/core/connection.py
+++ b/main/xiaozhi-server/core/connection.py
@@ -808,6 +808,7 @@ class ConnectionHandler:
                 self.headers.get("client-id", self.headers.get("device-id")),
             )
             private_config["delete_audio"] = bool(self.config.get("delete_audio", True))
+            private_config["tts_timeout"] = self.config.get("tts_timeout", 15)
             self.logger.bind(tag=TAG).info(
                 f"{time.time() - begin_time} 秒，异步获取差异化配置成功: {json.dumps(filter_sensitive_info(private_config), ensure_ascii=False)}"
             )

--- a/main/xiaozhi-server/core/providers/tts/aliyun.py
+++ b/main/xiaozhi-server/core/providers/tts/aliyun.py
@@ -31,7 +31,7 @@ class AccessToken:
         return encoded_text.replace("+", "%20").replace("*", "%2A").replace("%7E", "~")
 
     @staticmethod
-    def create_token(access_key_id, access_key_secret):
+    def create_token(access_key_id, access_key_secret, timeout):
         parameters = {
             "AccessKeyId": access_key_id,
             "Action": "CreateToken",
@@ -73,7 +73,7 @@ class AccessToken:
         )
         # print('url: %s' % full_url)
         # 提交HTTP GET请求
-        response = requests.get(full_url)
+        response = requests.get(full_url, timeout=timeout)
         if response.ok:
             root_obj = response.json()
             key = "Token"
@@ -135,7 +135,7 @@ class TTSProvider(TTSProviderBase):
         """刷新Token并记录过期时间"""
         if self.access_key_id and self.access_key_secret:
             self.token, expire_time_str = AccessToken.create_token(
-                self.access_key_id, self.access_key_secret
+                self.access_key_id, self.access_key_secret, self.tts_timeout
             )
             if not expire_time_str:
                 raise ValueError("无法获取有效的Token过期时间")
@@ -189,12 +189,18 @@ class TTSProvider(TTSProviderBase):
         # print(self.api_url, json.dumps(request_json, ensure_ascii=False))
         try:
             resp = requests.post(
-                self.api_url, json.dumps(request_json), headers=self.header
+                self.api_url,
+                json.dumps(request_json),
+                headers=self.header,
+                timeout=self.tts_timeout,
             )
             if resp.status_code == 401:  # Token过期特殊处理
                 self._refresh_token()
                 resp = requests.post(
-                    self.api_url, json.dumps(request_json), headers=self.header
+                    self.api_url,
+                    json.dumps(request_json),
+                    headers=self.header,
+                    timeout=self.tts_timeout,
                 )
             # 检查返回请求数据的mime类型是否是audio/***，是则保存到指定路径下；返回的是binary格式的
             if resp.headers["Content-Type"].startswith("audio/"):

--- a/main/xiaozhi-server/core/providers/tts/aliyun_stream.py
+++ b/main/xiaozhi-server/core/providers/tts/aliyun_stream.py
@@ -38,7 +38,7 @@ class AccessToken:
         return encoded_text.replace("+", "%20").replace("*", "%2A").replace("%7E", "~")
 
     @staticmethod
-    def create_token(access_key_id, access_key_secret):
+    def create_token(access_key_id, access_key_secret, timeout):
         parameters = {
             "AccessKeyId": access_key_id,
             "Action": "CreateToken",
@@ -75,7 +75,7 @@ class AccessToken:
 
         import requests
 
-        response = requests.get(full_url)
+        response = requests.get(full_url, timeout=timeout)
         if response.ok:
             root_obj = response.json()
             key = "Token"
@@ -152,7 +152,7 @@ class TTSProvider(TTSProviderBase):
         """刷新Token并记录过期时间"""
         if self.access_key_id and self.access_key_secret:
             self.token, expire_time_str = AccessToken.create_token(
-                self.access_key_id, self.access_key_secret
+                self.access_key_id, self.access_key_secret, self.tts_timeout
             )
             if not expire_time_str:
                 raise ValueError("无法获取有效的Token过期时间")

--- a/main/xiaozhi-server/core/providers/tts/base.py
+++ b/main/xiaozhi-server/core/providers/tts/base.py
@@ -1,5 +1,6 @@
 import os
 import re
+import math
 import uuid
 import queue
 import asyncio
@@ -37,7 +38,9 @@ class TTSProviderBase(ABC):
         self.delete_audio_file = delete_audio_file
         self.audio_file_type = "wav"
         self.output_file = config.get("output_dir", "tmp/")
-        self.tts_timeout = int(config.get("tts_timeout", 15))
+        self.tts_timeout = float(config.get("tts_timeout", 15))
+        if not math.isfinite(self.tts_timeout) or self.tts_timeout <= 0:
+            raise ValueError("tts_timeout must be a positive finite number")
         self.tts_text_queue = queue.Queue()
         self.tts_audio_queue = queue.Queue()
         self.tts_audio_first_sentence = True

--- a/main/xiaozhi-server/core/providers/tts/cozecn.py
+++ b/main/xiaozhi-server/core/providers/tts/cozecn.py
@@ -47,7 +47,11 @@ class TTSProvider(TTSProviderBase):
 
         try:
             response = requests.request(
-                "POST", self.api_url, json=request_json, headers=headers
+                "POST",
+                self.api_url,
+                json=request_json,
+                headers=headers,
+                timeout=self.tts_timeout,
             )
             data = response.content
             if output_file:

--- a/main/xiaozhi-server/core/providers/tts/custom.py
+++ b/main/xiaozhi-server/core/providers/tts/custom.py
@@ -38,9 +38,19 @@ class TTSProvider(TTSProviderBase):
             request_params[k] = v
 
         if self.method.upper() == "POST":
-            resp = requests.post(self.url, json=request_params, headers=self.headers)
+            resp = requests.post(
+                self.url,
+                json=request_params,
+                headers=self.headers,
+                timeout=self.tts_timeout,
+            )
         else:
-            resp = requests.get(self.url, params=request_params, headers=self.headers)
+            resp = requests.get(
+                self.url,
+                params=request_params,
+                headers=self.headers,
+                timeout=self.tts_timeout,
+            )
         if resp.status_code == 200:
             if output_file:
                 with open(output_file, "wb") as file:

--- a/main/xiaozhi-server/core/providers/tts/doubao.py
+++ b/main/xiaozhi-server/core/providers/tts/doubao.py
@@ -80,7 +80,10 @@ class TTSProvider(TTSProviderBase):
 
         try:
             resp = requests.post(
-                self.api_url, json.dumps(request_json), headers=self.header
+                self.api_url,
+                json.dumps(request_json),
+                headers=self.header,
+                timeout=self.tts_timeout,
             )
             if "data" in resp.json():
                 data = resp.json()["data"]

--- a/main/xiaozhi-server/core/providers/tts/fishspeech.py
+++ b/main/xiaozhi-server/core/providers/tts/fishspeech.py
@@ -169,6 +169,7 @@ class TTSProvider(TTSProviderBase):
                 "Authorization": f"Bearer {self.api_key}",
                 "Content-Type": "application/msgpack",
             },
+            timeout=self.tts_timeout,
         )
 
         if response.status_code == 200:

--- a/main/xiaozhi-server/core/providers/tts/gpt_sovits_v2.py
+++ b/main/xiaozhi-server/core/providers/tts/gpt_sovits_v2.py
@@ -90,7 +90,9 @@ class TTSProvider(TTSProviderBase):
             "repetition_penalty": self.repetition_penalty,
         }
 
-        resp = requests.post(self.url, json=request_json)
+        resp = requests.post(
+            self.url, json=request_json, timeout=self.tts_timeout
+        )
         if resp.status_code == 200:
             if output_file:
                 with open(output_file, "wb") as file:

--- a/main/xiaozhi-server/core/providers/tts/gpt_sovits_v3.py
+++ b/main/xiaozhi-server/core/providers/tts/gpt_sovits_v3.py
@@ -51,7 +51,9 @@ class TTSProvider(TTSProviderBase):
             "if_sr": self.if_sr,
         }
 
-        resp = requests.get(self.url, params=request_params)
+        resp = requests.get(
+            self.url, params=request_params, timeout=self.tts_timeout
+        )
         if resp.status_code == 200:
             if output_file:
                 with open(output_file, "wb") as file:

--- a/main/xiaozhi-server/core/providers/tts/index_stream.py
+++ b/main/xiaozhi-server/core/providers/tts/index_stream.py
@@ -130,7 +130,9 @@ class TTSProvider(TTSProviderBase):
         )  # 16-bit = 2 bytes
         try:
             async with aiohttp.ClientSession() as session:
-                async with session.post(self.api_url, json=payload, timeout=10) as resp:
+                async with session.post(
+                    self.api_url, json=payload, timeout=self.tts_timeout
+                ) as resp:
 
                     if resp.status != 200:
                         logger.bind(tag=TAG).error(
@@ -212,7 +214,9 @@ class TTSProvider(TTSProviderBase):
         payload = {"text": text, "character": self.voice}
 
         try:
-            with requests.post(self.api_url, json=payload, timeout=5) as response:
+            with requests.post(
+                self.api_url, json=payload, timeout=self.tts_timeout
+            ) as response:
                 if response.status_code != 200:
                     logger.bind(tag=TAG).error(
                         f"TTS请求失败: {response.status_code}, {response.text}"

--- a/main/xiaozhi-server/core/providers/tts/minimax_httpstream.py
+++ b/main/xiaozhi-server/core/providers/tts/minimax_httpstream.py
@@ -201,7 +201,7 @@ class TTSProvider(TTSProviderBase):
                     self.api_url,
                     headers=self.header,
                     data=json.dumps(payload),
-                    timeout=10,
+                    timeout=self.tts_timeout,
                 ) as resp:
 
                     if resp.status != 200:
@@ -324,7 +324,10 @@ class TTSProvider(TTSProviderBase):
 
         try:
             with requests.post(
-                self.api_url, data=json.dumps(payload), headers=headers, timeout=5
+                self.api_url,
+                data=json.dumps(payload),
+                headers=headers,
+                timeout=self.tts_timeout,
             ) as response:
                 if response.status_code != 200:
                     logger.bind(tag=TAG).error(

--- a/main/xiaozhi-server/core/providers/tts/openai.py
+++ b/main/xiaozhi-server/core/providers/tts/openai.py
@@ -47,7 +47,9 @@ class TTSProvider(TTSProviderBase):
             "response_format": self.audio_file_type,
             "speed": self.speed,
         }
-        response = requests.post(self.api_url, json=data, headers=headers)
+        response = requests.post(
+            self.api_url, json=data, headers=headers, timeout=self.tts_timeout
+        )
         if response.status_code == 200:
             if output_file:
                 with open(output_file, "wb") as audio_file:

--- a/main/xiaozhi-server/core/providers/tts/paddle_speech.py
+++ b/main/xiaozhi-server/core/providers/tts/paddle_speech.py
@@ -111,7 +111,7 @@ class TTSProvider(TTSProviderBase):
                 await ws.send(json.dumps(data_request))
 
                 audio_chunks = b""
-                timeout_seconds = 60  # 设置超时
+                timeout_seconds = self.tts_timeout
                 try:
                     while True:
                         response = await asyncio.wait_for(ws.recv(), timeout=timeout_seconds)

--- a/main/xiaozhi-server/core/providers/tts/tencent.py
+++ b/main/xiaozhi-server/core/providers/tts/tencent.py
@@ -154,7 +154,10 @@ class TTSProvider(TTSProviderBase):
 
             # 发送请求
             resp = requests.post(
-                self.api_url, json.dumps(request_json), headers=headers
+                self.api_url,
+                json.dumps(request_json),
+                headers=headers,
+                timeout=self.tts_timeout,
             )
 
             # 检查响应

--- a/main/xiaozhi-server/core/utils/modules_initialize.py
+++ b/main/xiaozhi-server/core/utils/modules_initialize.py
@@ -100,14 +100,16 @@ def initialize_modules(
 
 def initialize_tts(config):
     select_tts_module = config["selected_module"]["TTS"]
+    tts_config = config["TTS"][select_tts_module].copy()
+    tts_config.setdefault("tts_timeout", config.get("tts_timeout", 15))
     tts_type = (
         select_tts_module
-        if "type" not in config["TTS"][select_tts_module]
-        else config["TTS"][select_tts_module]["type"]
+        if "type" not in tts_config
+        else tts_config["type"]
     )
     new_tts = tts.create_instance(
         tts_type,
-        config["TTS"][select_tts_module],
+        tts_config,
         str(config.get("delete_audio", True)).lower() in ("true", "1", "yes"),
     )
     return new_tts
@@ -148,4 +150,3 @@ def initialize_voiceprint(asr_instance, config):
     except Exception as e:
         logger.bind(tag=TAG).error(f"动态初始化声纹识别功能失败: {str(e)}")
         return False
-


### PR DESCRIPTION
## 问题

全局 `tts_timeout` 虽然在服务配置中定义，但初始化 TTS provider 时只传入具体模型配置，导致顶层值未生效，provider 实际回退到基类默认值。

同时，多个 TTS provider 的 HTTP 或 WebSocket 请求未设置超时，或仍硬编码为 5、10、60 秒，无法统一受全局配置控制。

## 修改

- 初始化 TTS provider 时注入顶层 `tts_timeout`，保留 provider 级配置的覆盖能力，缺失时默认 15 秒。
- Manager API 私有配置路径同步传递公共 `tts_timeout`。
- 本地配置默认值调整为 15 秒。
- 新增 Liquibase 迁移，仅将仍为旧默认值 10 的 Manager API 参数更新为 15，不覆盖其他自定义值。
- 为 Aliyun、Coze、Custom、OpenAI、Doubao、FishSpeech、GPT-SoVITS、Tencent、IndexTTS、Minimax 等 HTTP 请求统一使用 `self.tts_timeout`。
- PaddleSpeech WebSocket 接收超时改为使用 `self.tts_timeout`。
- WebSocket 的 ping、close 等连接维护超时保持原有独立配置。

## 验证

- Manager API 全量测试：126/126 通过。
- Liquibase 新迁移在现有数据库上执行成功，再次启动显示数据库已是最新状态。
- Python TTS 及初始化相关源码全量语法检查通过。
- 静态扫描确认 18 处 TTS HTTP 请求和 PaddleSpeech WebSocket 接收均使用统一超时配置。
- Liquibase master 校验通过，共 104 个唯一 changeset，引用文件均存在。
- `git diff --check` 通过。

未使用各 TTS 服务的真实密钥进行在线调用验证。
