### PR TITLE
fix(知识库管理): 上传弹窗禁止点击遮罩关闭并添加提交加载状态

### DIFF
--- a/main/manager-web/src/views/KnowledgeBaseManagement.vue
+++ b/main/manager-web/src/views/KnowledgeBaseManagement.vue
@@ -148,6 +148,8 @@
       :title="$t('knowledgeFileUpload.uploadDocument')"
       :visible.sync="uploadDialogVisible"
       width="800px"
+      :close-on-click-modal="false"
+      :confirmLoading="uploading"
       @close="handleUploadDialogClose"
       @confirm="handleBatchUploadSubmit"
     >


### PR DESCRIPTION
给 [确认保存] 按钮增加 加载状态
<img width="923" height="443" alt="image" src="https://github.com/user-attachments/assets/0f974c25-c716-41e5-a6e4-46a2ccba28e1" />
