### PR TITLE
fix: send server hello before MCP initialize

### DIFF
--- a/main/xiaozhi-server/core/handle/helloHandle.py
+++ b/main/xiaozhi-server/core/handle/helloHandle.py
@@ -54,13 +54,15 @@ async def handleHelloMessage(conn: "ConnectionHandler", msg_json):
         if features.get("mcp"):
             conn.logger.bind(tag=TAG).debug("客户端支持MCP")
             conn.mcp_client = MCPClient()
-            # 发送初始化
-            asyncio.create_task(send_mcp_initialize_message(conn))
         if features.get("aec"):
             conn.logger.bind(tag=TAG).debug("客户端启用了服务端AEC")
             conn.client_aec = True
 
     await conn.websocket.send(json.dumps(conn.welcome_msg))
+
+    # The device waits for the server hello before processing MCP messages.
+    if features and features.get("mcp"):
+        asyncio.create_task(send_mcp_initialize_message(conn))
 
 
 async def checkWakeupWords(conn: "ConnectionHandler", text):


### PR DESCRIPTION
Fixes #3347

## What changed

`handleHelloMessage()` scheduled `send_mcp_initialize_message()` before awaiting `conn.websocket.send(conn.welcome_msg)`, so the MCP frame could be delivered before the server `hello`. The MCP task is now created after the server `hello` has been sent.

## Why

The ESP32 firmware waits for the server `hello` before marking the audio channel ready (`main/protocols/websocket_protocol.cc`). When the MCP `initialize` arrived first, ESP-HI `2.2.6` never answered it and the session was torn down.

## Verification

Real device (ESP-HI `2.2.6`, ESP32-C3), over `wss://`:

- before: server `hello` sent after the MCP task, device never returned an `initialize` result
- after: device returns the `initialize` result (`serverInfo.name=esp-hi`, `version=2.2.6`) and all 8 tools from `tools/list`
- device tool calls now succeed, e.g. `self.dog.basic_control {"action":"forward"} -> true`
