### PR TITLE
fix: disable library WebSocket keepalive for device server

### DIFF
--- a/main/xiaozhi-server/core/websocket_server.py
+++ b/main/xiaozhi-server/core/websocket_server.py
@@ -74,7 +74,11 @@ class WebSocketServer:
         port = int(server_config.get("port", 8000))
 
         async with websockets.serve(
-            self._handle_connection, host, port, process_request=self._http_response
+            self._handle_connection,
+            host,
+            port,
+            process_request=self._http_response,
+            ping_interval=None,
         ):
             await asyncio.Future()
 


### PR DESCRIPTION
Fixes #3348

## What changed

`websockets.serve()` is now started with `ping_interval=None` in `core/websocket_server.py`.

## Why

Without it, the `websockets` package applies its default keepalive (`ping_interval=20`, `ping_timeout=20`). ESP32 clients that do not answer those control frames are dropped from an otherwise healthy session:

```text
1011 (internal error) keepalive ping timeout; no close frame received
```

Observed on ESP-HI `2.2.6` roughly 40 seconds into every session, with both `ws://` and `wss://`, and also with TTS audio and TTS JSON disabled. Note the application-level ping is a separate feature configured through `enable_websocket_ping`, so it is unaffected.

## Verification

Real device (ESP-HI `2.2.6`, ESP32-C3): the `keepalive ping timeout` disconnects no longer occur, and the device stays usable across repeated ASR / LLM / MCP / TTS turns over `wss://`.
