### PR TITLE
fix: pace initial Opus frames for low-memory clients

### DIFF
--- a/main/xiaozhi-server/core/handle/sendAudioHandle.py
+++ b/main/xiaozhi-server/core/handle/sendAudioHandle.py
@@ -14,8 +14,9 @@ from core.utils.audioRateController import AudioRateController
 TAG = __name__
 # 音频帧时长（毫秒）
 AUDIO_FRAME_DURATION = 60
-# 预缓冲包数量，直接发送以减少延迟
-PRE_BUFFER_COUNT = 5
+# 预缓冲包数量。部分 ESP32-C3 客户端接收缓冲不足，突发预缓冲会导致播放中断，
+# 因此默认不做突发发送，全部交给 60ms 速率控制器。
+PRE_BUFFER_COUNT = 0
 
 
 async def sendAudioMessage(conn: "ConnectionHandler", sentenceType, audios, text, sentence_id=None):


### PR DESCRIPTION
Fixes #3349

## What changed

`PRE_BUFFER_COUNT` in `core/handle/sendAudioHandle.py` is changed from `5` to `0`, so every Opus frame goes through the 60 ms rate controller instead of the first five bypassing it.

## Why

The bypass delivered about 360 ms of Opus audio in about 10 ms. Instrumented send times on the current code:

```text
frame 0:   0 ms
frame 1:   2 ms
frame 2:   4 ms
frame 3:   5 ms
frame 4:   7 ms
frame 5:  10 ms
frame 6:  71 ms
```

On ESP32-C3 (ESP-HI `2.2.6`, ~80 KB free heap, no PSRAM) playback was cut off after roughly one syllable.

With `PRE_BUFFER_COUNT = 0`:

```text
frame 0:   0 ms
frame 1:  60 ms
frame 2: 122 ms
frame 3: 181 ms
```

## Verification

Real device (ESP-HI `2.2.6`): short and multi-sentence replies now play to completion (verified with 54, 56, 75, 103 and 130 frame responses) and the device no longer reboots mid-playback.

If the latency saved by the burst matters for other boards, this could be made configurable per connection rather than removed outright — happy to rework it that way.
