### PR TITLE
chore(deps): batch bump 3 allowed deps (modelscope, silero-vad, chardet)

### DIFF
--- a/main/xiaozhi-server/requirements.txt
+++ b/main/xiaozhi-server/requirements.txt
@@ -7,7 +7,7 @@ numpy==1.26.4
 websockets==14.2
 #--------- 以下是可升级的依赖
 pyyml==0.0.2
-silero_vad==6.1.0
+silero_vad==6.2.1
 opuslib_next==1.1.5
 pydub==0.25.1
 funasr==1.2.7
@@ -25,14 +25,14 @@ cozepy==0.20.0
 mem0ai==1.0.0
 powermem>=0.3.1
 bs4==0.0.2
-modelscope==1.32.0
+modelscope==1.39.1
 sherpa_onnx==1.12.29
 mcp==1.22.0
 cnlunar==0.2.0
 PySocks==1.7.1
 dashscope==1.25.2
 baidu-aip==4.16.13
-chardet==5.2.0
+chardet==7.6.0
 aioconsole==0.8.2
 markitdown==0.1.3
 mcp-proxy==0.10.0


### PR DESCRIPTION
## 背景
GitHub 上 dependabot 开了多个零散的依赖升级 PR（#3359 modelscope、#3362 silero-vad、#3363 chardet），每个只升级一个依赖。为了减少 PR 噪音、便于集中 review，把这三个升级合并到这一个 PR。

## 改动
- `modelscope`: 1.32.0 -> 1.39.1（来自 #3359，CI PASS）
- `silero_vad`: 6.1.0 -> 6.2.1（来自 #3362，CI PASS）
- `chardet`: 5.2.0 -> 7.6.0（来自 #3363，CI PASS）

三处都位于 `#--------- 以下是可升级的依赖` 区域，未触碰 numpy / torch / websockets 等被显式标注不推荐升级的依赖。

## 主动拒绝的 PR
- #3360 portalocker 3.2.0 -> 4.3.0：CI Python job FAILURE
- #3361 numpy 1.26.4 -> 2.5.2：违反 requirements.txt 第 2-5 行的 Python 3.10 兼容性约束，且 CI Python job FAILURE

## 验证
- 本地 Python 3.13 环境（与 CI Python 3.10 不同，仅作 wheel 安装性验证）三个新版本均可直接 wheel 安装
- 在 `main/xiaozhi-server/` 下跑 `pytest tests/`，新版本与原版本结果一致：`45 passed, 2 skipped`（2 skip 来自 `data/.config.yaml` 缺失，与依赖升级无关）

## 局限
- pytest 套件当前仅是 smoke 级别（test.yml 也只跑 `test_smoke.py`），并不能充分验证依赖兼容性。强烈建议 maintainer 合并前在 PR 上 re-run CI 并人工 spot-check 真正用到 chardet/silero_vad/modelscope 的代码路径。